### PR TITLE
refactor: directly get request array buffer instead of reading stream

### DIFF
--- a/src/keri/core/authing.ts
+++ b/src/keri/core/authing.ts
@@ -195,7 +195,7 @@ export class Authenticator {
         });
 
         let body = '';
-        if (request.method !== 'GET' && request.body) {
+        if (request.method !== 'GET') {
             body = Buffer.from(await request.arrayBuffer()).toString('utf-8');
         }
 

--- a/src/keri/core/authing.ts
+++ b/src/keri/core/authing.ts
@@ -196,11 +196,7 @@ export class Authenticator {
 
         let body = '';
         if (request.method !== 'GET' && request.body) {
-            // Response provides convenience method to extract, better compatibility.
-            const tmpResponse = new Response(request.body);
-            body = Buffer.from(await tmpResponse.arrayBuffer()).toString(
-                'utf-8'
-            );
+            body = Buffer.from(await request.arrayBuffer()).toString('utf-8');
         }
 
         return `${request.method} ${request.url} HTTP/1.1\r\n${headers}\r\n${body}`;

--- a/src/keri/core/authing.ts
+++ b/src/keri/core/authing.ts
@@ -196,37 +196,14 @@ export class Authenticator {
 
         let body = '';
         if (request.method !== 'GET' && request.body) {
-            body = Buffer.from(await this.streamToBytes(request.body)).toString(
+            // Response provides convenience method to extract, better compatibility.
+            const tmpResponse = new Response(request.body);
+            body = Buffer.from(await tmpResponse.arrayBuffer()).toString(
                 'utf-8'
             );
         }
 
         return `${request.method} ${request.url} HTTP/1.1\r\n${headers}\r\n${body}`;
-    }
-
-    private static async streamToBytes(stream: ReadableStream) {
-        const reader = stream.getReader();
-        const chunks = [];
-        let done, value;
-
-        while ((({ done, value } = await reader.read()), !done)) {
-            if (value) chunks.push(value);
-        }
-        reader.releaseLock();
-
-        const totalLength = chunks.reduce(
-            (acc, chunk) => acc + chunk.length,
-            0
-        );
-        const result = new Uint8Array(totalLength);
-        let offset = 0;
-
-        for (const chunk of chunks) {
-            result.set(chunk, offset);
-            offset += chunk.length;
-        }
-
-        return result;
     }
 
     async unwrap(


### PR DESCRIPTION
No need to manually do this.

This is also a fix for some Android WebViews, where despite a body existing (and `arrayBuffer()` returning bytes), `request.body` is `undefined`. Not sure.