### PR TITLE
fix(serder): correctly parse string/hex sequence number

### DIFF
--- a/src/keri/core/serder.ts
+++ b/src/keri/core/serder.ts
@@ -59,7 +59,7 @@ export class Serder {
     }
 
     get sner(): CesrNumber {
-        return new CesrNumber({}, this.ked['s']);
+        return new CesrNumber({}, undefined, this.ked['s']);
     }
 
     get sn(): number {

--- a/test/core/number.test.ts
+++ b/test/core/number.test.ts
@@ -29,5 +29,25 @@ describe('THolder', () => {
         n = new CesrNumber({}, undefined, '15');
         assert.equal(n.num, 21);
         assert.equal(n.numh, '15');
+
+        n = new CesrNumber({}, 39);
+        assert.equal(n.num, 39);
+        assert.equal(n.numh, '27');
+    
+        n = new CesrNumber({}, '39');
+        assert.equal(n.num, 0);
+        assert.equal(n.numh, '0');
+
+        n = new CesrNumber({}, undefined, '39');
+        assert.equal(n.num, 57);
+        assert.equal(n.numh, '39');
+
+        n = new CesrNumber({}, '3a');
+        assert.equal(n.num, 0);
+        assert.equal(n.numh, '0');
+
+        n = new CesrNumber({}, undefined, '3a');
+        assert.equal(n.num, 58);
+        assert.equal(n.numh, '3a');
     });
 });

--- a/test/core/serder.test.ts
+++ b/test/core/serder.test.ts
@@ -6,7 +6,6 @@ import { Diger } from '../../src/keri/core/diger';
 import { Serder } from '../../src/keri/core/serder';
 import libsodium from 'libsodium-wrappers-sumo';
 import { Prefixer } from '../../src/keri/core/prefixer.ts';
-import { CesrNumber } from '../../src/keri/core/number.ts';
 
 describe('deversify', () => {
     it('should parse a KERI event version string', async () => {

--- a/test/core/serder.test.ts
+++ b/test/core/serder.test.ts
@@ -5,7 +5,8 @@ import { MtrDex } from '../../src/keri/core/matter';
 import { Diger } from '../../src/keri/core/diger';
 import { Serder } from '../../src/keri/core/serder';
 import libsodium from 'libsodium-wrappers-sumo';
-import { Prefixer } from '../../src/keri/core/prefixer';
+import { Prefixer } from '../../src/keri/core/prefixer.ts';
+import { CesrNumber } from '../../src/keri/core/number.ts';
 
 describe('deversify', () => {
     it('should parse a KERI event version string', async () => {
@@ -72,8 +73,8 @@ describe('Serder', () => {
         assert.equal(
             serder.raw,
             '{"v":"KERI10JSON0000d3_","t":"icp","d":"","i":"","s":"0","kt":"1","k":' +
-                '["DAUDqkmn-hqlQKD8W-FAEa5JUvJC2I9yarEem-AAEg3e"],"nt":"1",' +
-                '"n":["EAKUR-LmLHWMwXTLWQ1QjxHrihBmwwrV2tYaSG7hOrWj"],"bt":"0","b":[],"c":[],"a":[]}'
+            '["DAUDqkmn-hqlQKD8W-FAEa5JUvJC2I9yarEem-AAEg3e"],"nt":"1",' +
+            '"n":["EAKUR-LmLHWMwXTLWQ1QjxHrihBmwwrV2tYaSG7hOrWj"],"bt":"0","b":[],"c":[],"a":[]}'
         );
         let aid0 = new Prefixer({ code: MtrDex.Ed25519 }, ked0);
         assert.equal(aid0.code, MtrDex.Ed25519);
@@ -94,4 +95,31 @@ describe('Serder', () => {
         });
         assert.equal(serder1.ked.v, 'KERI10JSON000139_');
     });
+
+    it('should interpret Serder sequence number correctly from event data', async () => {
+        await libsodium.ready;
+
+        const ked = {
+            v: 'KERI10JSON00013b_',
+            t: Ilks.ixn,
+            d: 'EISfGQrKJscFXScIV_n2pMzvZuBiSZtMxP0E64sAq6p3',
+            i: 'ED88Jn6CnWpNbSYz6vp9DOSpJH2_Di5MSwWTf1l34JJm',
+            s: '39',
+            p: 'EMF5t6OYToET4JD11FkU9Axtsp_w8Su2rtJ8Wbuev-6U',
+            a: [
+                {
+                    i: 'EN9r-cXzNm72-rPyPUzLTgfsXQ6IJn_TvQGqANRFEo5_',
+                    s: '0',
+                    d: 'EGwYEisTlJiQUtiFJlQvbh_NC3YDrr8p8VvwgvEDozkT',
+                },
+            ],
+        };
+
+        const serder = new Serder(ked);
+
+        assert.equal(serder.sn, 57);
+        assert.equal(serder.sner.num, 57);
+        assert.equal(serder.sner.numh, '39');
+    });
+
 });


### PR DESCRIPTION
- Ensure Serder.sn is parsed correctly for string sequence values.
-  update tests for serder and number