### PR TITLE
feat: split rotate into createRotationData and submitRotationData

### DIFF
--- a/src/keri/app/aiding.ts
+++ b/src/keri/app/aiding.ts
@@ -65,7 +65,6 @@ export interface RotateIdentifierArgs {
 }
 
 export interface RotateIdentifierBody {
-    name: string,
     rot: EstablishmentEvent,
     sigs: string[],
     smids?: string[],
@@ -358,12 +357,6 @@ export class Identifier {
         return { serder, sigs, jsondata };
     }
 
-    /**
-     * Generate a rotation event in a managed identifier
-     * @param {string} name Name or alias of the identifier
-     * @param {RotateIdentifierArgs} [kargs] Optional parameters requiered to generate the rotation event
-     * @returns {Promise<EventResult>} A promise to the rotation event result
-     */
     async createRotationData(
         name: string,
         kargs: RotateIdentifierArgs = {}
@@ -435,7 +428,6 @@ export class Identifier {
         const sigs = await keeper.sign(b(serder.raw));
 
         const body: any = {
-            name,
             rot: serder.ked,
             sigs: sigs,
             smids:
@@ -452,23 +444,29 @@ export class Identifier {
     }
 
     async submitRotationData(
+        name: string,
         jsondata: RotateIdentifierBody
     ): Promise<EventResult> {
-        const { name, ...body } = jsondata;
         const res = await this.client.fetch(
             '/identifiers/' + name + '/events',
             'POST',
-            body
+            jsondata
         );
         return new EventResult(new Serder(jsondata.rot), jsondata.sigs, res);
     }
 
+    /**
+     * Rotate a managed identifier
+     * @param {string} name Name or alias of the identifier
+     * @param {RotateIdentifierArgs} [kargs] Optional parameters requiered to generate the rotation event
+     * @returns {Promise<EventResult>} A promise to the rotation event result
+     */
     async rotate(
         name: string,
         kargs: RotateIdentifierArgs = {}
     ): Promise<EventResult> {
         const jsondata = await this.createRotationData(name, kargs);
-        return await this.submitRotationData(jsondata);
+        return await this.submitRotationData(name, jsondata);
     }
 
     /**

--- a/src/keri/app/aiding.ts
+++ b/src/keri/app/aiding.ts
@@ -64,6 +64,18 @@ export interface RotateIdentifierArgs {
     rstates?: any[];
 }
 
+export interface RotateIdentifierBody {
+    name: string,
+    rot: EstablishmentEvent,
+    sigs: string[],
+    smids?: string[],
+    rmids?: string[],
+    [Algos.salty]?: SaltyState;
+    [Algos.randy]?: RandyState;
+    [Algos.group]?: GroupState;
+    [Algos.extern]?: ExternState;
+}
+
 /**
  * Reducing the SignifyClient dependencies used by Identifier class
  */
@@ -352,10 +364,10 @@ export class Identifier {
      * @param {RotateIdentifierArgs} [kargs] Optional parameters requiered to generate the rotation event
      * @returns {Promise<EventResult>} A promise to the rotation event result
      */
-    async rotate(
+    async createRotationData(
         name: string,
         kargs: RotateIdentifierArgs = {}
-    ): Promise<EventResult> {
+    ): Promise<RotateIdentifierBody> {
         const transferable = kargs.transferable ?? true;
         const ncode = kargs.ncode ?? MtrDex.Ed25519_Seed;
         const ncount = kargs.ncount ?? 1;
@@ -422,7 +434,8 @@ export class Identifier {
 
         const sigs = await keeper.sign(b(serder.raw));
 
-        const jsondata: any = {
+        const body: any = {
+            name,
             rot: serder.ked,
             sigs: sigs,
             smids:
@@ -434,14 +447,28 @@ export class Identifier {
                     ? rstates.map((state) => state.i)
                     : undefined,
         };
-        jsondata[keeper.algo] = keeper.params();
+        body[keeper.algo] = keeper.params();
+        return body;
+    }
 
+    async submitRotationData(
+        jsondata: RotateIdentifierBody
+    ): Promise<EventResult> {
+        const { name, ...body } = jsondata;
         const res = await this.client.fetch(
             '/identifiers/' + name + '/events',
             'POST',
-            jsondata
+            body
         );
-        return new EventResult(serder, sigs, res);
+        return new EventResult(new Serder(jsondata.rot), jsondata.sigs, res);
+    }
+
+    async rotate(
+        name: string,
+        kargs: RotateIdentifierArgs = {}
+    ): Promise<EventResult> {
+        const jsondata = await this.createRotationData(name, kargs);
+        return await this.submitRotationData(jsondata);
     }
 
     /**

--- a/test/app/aiding.test.ts
+++ b/test/app/aiding.test.ts
@@ -283,8 +283,6 @@ describe('Aiding', () => {
         assert.equal(lastCall.path, '/identifiers/aid1');
         assert.equal(lastCall.method, 'GET');
 
-        // name is not part of the body, it only drives the submit url
-        assert.equal((body as any).name, undefined);
         assert.equal(body.rot.t, 'rot');
         assert.equal(body.rot.s, '1');
         assert.equal(body.sigs.length, 1);

--- a/test/app/aiding.test.ts
+++ b/test/app/aiding.test.ts
@@ -283,7 +283,8 @@ describe('Aiding', () => {
         assert.equal(lastCall.path, '/identifiers/aid1');
         assert.equal(lastCall.method, 'GET');
 
-        assert.equal(body.name, 'aid1');
+        // name is not part of the body, it only drives the submit url
+        assert.equal((body as any).name, undefined);
         assert.equal(body.rot.t, 'rot');
         assert.equal(body.rot.s, '1');
         assert.equal(body.sigs.length, 1);
@@ -296,17 +297,15 @@ describe('Aiding', () => {
         const body = await client.identifiers().createRotationData('aid1');
 
         client.fetch.mockResolvedValueOnce(Response.json({}));
-        await client.identifiers().submitRotationData(body);
+        await client.identifiers().submitRotationData('aid1', body);
         const first = client.getLastMockRequest();
 
         client.fetch.mockResolvedValueOnce(Response.json({}));
-        await client.identifiers().submitRotationData(body);
+        await client.identifiers().submitRotationData('aid1', body);
         const second = client.getLastMockRequest();
 
         assert.equal(first.path, '/identifiers/aid1/events');
         assert.equal(first.method, 'POST');
-        // the name only drives the url, it is not part of the posted body
-        assert.equal(first.body.name, undefined);
         assert.deepEqual(first.body.rot, body.rot);
         assert.deepEqual(first.body.sigs, body.sigs);
         // resubmitting the same body posts the exact same event

--- a/test/app/aiding.test.ts
+++ b/test/app/aiding.test.ts
@@ -272,6 +272,48 @@ describe('Aiding', () => {
         });
     });
 
+    it('createRotationData builds the event without submitting it', async () => {
+        const aid1 = await createMockIdentifierState('aid1', bran, {});
+        client.fetch.mockResolvedValueOnce(Response.json(aid1));
+
+        const body = await client.identifiers().createRotationData('aid1');
+
+        // only the state lookup happened, no POST to /events
+        const lastCall = client.getLastMockRequest();
+        assert.equal(lastCall.path, '/identifiers/aid1');
+        assert.equal(lastCall.method, 'GET');
+
+        assert.equal(body.name, 'aid1');
+        assert.equal(body.rot.t, 'rot');
+        assert.equal(body.rot.s, '1');
+        assert.equal(body.sigs.length, 1);
+        assert.equal(body.salty!.kidx, 1);
+    });
+
+    it('submitRotationData submits a prebuilt event idempotently', async () => {
+        const aid1 = await createMockIdentifierState('aid1', bran, {});
+        client.fetch.mockResolvedValueOnce(Response.json(aid1));
+        const body = await client.identifiers().createRotationData('aid1');
+
+        client.fetch.mockResolvedValueOnce(Response.json({}));
+        await client.identifiers().submitRotationData(body);
+        const first = client.getLastMockRequest();
+
+        client.fetch.mockResolvedValueOnce(Response.json({}));
+        await client.identifiers().submitRotationData(body);
+        const second = client.getLastMockRequest();
+
+        assert.equal(first.path, '/identifiers/aid1/events');
+        assert.equal(first.method, 'POST');
+        // the name only drives the url, it is not part of the posted body
+        assert.equal(first.body.name, undefined);
+        assert.deepEqual(first.body.rot, body.rot);
+        assert.deepEqual(first.body.sigs, body.sigs);
+        // resubmitting the same body posts the exact same event
+        assert.equal(second.body.rot.d, first.body.rot.d);
+        assert.deepEqual(second.body.sigs, first.body.sigs);
+    });
+
     it('Can create interact event', async () => {
         const data = [
             {


### PR DESCRIPTION
Mirrors the inception two-phase split (`createInceptionData` / `submitInceptionData`) for rotation. `createRotationData` builds and signs the rotation event without sending it, `submitRotationData(name, body)` posts it, and `rotate()` keeps its behaviour by composing both. This lets a client store the signed event and resubmit it idempotently (outbox) instead of rebuilding a fresh event on each retry. name stays out of `RotateIdentifierBody`, which is only the HTTP body.