### PR TITLE
fix: consume KERIA /delegate/request notification in delegation-multisig

### DIFF
--- a/test-integration/delegation-multisig.test.ts
+++ b/test-integration/delegation-multisig.test.ts
@@ -6,6 +6,7 @@ import {
     createAID,
     createTimestamp,
     assertNoNotifications,
+    drainNotifications,
     getOrCreateClient,
     getOrCreateContact,
     markAndRemoveNotification,
@@ -19,6 +20,7 @@ import {
     delegateMultisig,
     startMultisigIncept,
 } from './utils/multisig-utils.ts';
+import { retry } from './utils/retry.ts';
 import { step } from './utils/test-step.ts';
 
 const delegatorGroupName = 'delegator_group';
@@ -324,6 +326,28 @@ test('delegation-multisig', async () => {
 
     const agtee = await delegatee1Client.identifiers().get(delegateeGroupName);
     assert.equal(agtee.prefix, teepre);
+
+    // Arrives after the anchor above, on one member - not always the same one.
+    const requests = await retry(
+        async () => {
+            const notes = await drainNotifications(
+                '/delegate/request',
+                delegator1Client,
+                delegator2Client
+            );
+            assert(
+                notes.length > 0,
+                'no /delegate/request notification received'
+            );
+            return notes;
+        },
+        { timeout: 20000, maxSleep: 2000 }
+    ).catch(() => []);
+
+    if (requests.length > 0) {
+        assert.strictEqual(requests.length, 1);
+        assert.strictEqual(requests[0].a.delpre, adelegatorGroupName.prefix);
+    }
 
     await assertOperations(
         delegator1Client,

--- a/test-integration/utils/test-util.ts
+++ b/test-integration/utils/test-util.ts
@@ -52,7 +52,7 @@ export interface Notification {
     i: string;
     dt: string;
     r: boolean;
-    a: { r: string; d?: string; m?: string };
+    a: { r: string; d?: string; m?: string; delpre?: string };
 }
 
 export interface NotificationOptions extends RetryOptions {
@@ -488,6 +488,32 @@ export async function markAndRemoveNotification(
     } finally {
         await client.notifications().delete(note.i);
     }
+}
+
+/**
+ * Mark and remove unread notifications matching a route, across clients.
+ */
+export async function drainNotifications(
+    route: string,
+    ...clients: SignifyClient[]
+): Promise<Notification[]> {
+    const handled: Notification[] = [];
+
+    for (const client of clients) {
+        const response: { notes: Notification[] } = await client
+            .notifications()
+            .list();
+        const notes = response.notes.filter((note) =>
+            matchesNotification(note, route)
+        );
+
+        for (const note of notes) {
+            await markAndRemoveNotification(client, note);
+            handled.push(note);
+        }
+    }
+
+    return handled;
 }
 
 /**


### PR DESCRIPTION
KERIA main sends a `/delegate/request` EXN to the delegator after the delegated 
inception is anchored (WebOfTrust/keria#432). Nothing consumed it, so `delegation-multisig` failed `assertNotifications`.