### PR TITLE
feat: allow setting the signing threshold on rotation

### DIFF
--- a/src/keri/app/aiding.ts
+++ b/src/keri/app/aiding.ts
@@ -41,6 +41,7 @@ export interface CreateIdentiferArgs {
 /** Arguments required to rotate an identfier */
 export interface RotateIdentifierArgs {
     transferable?: boolean;
+    isith?: string | number | string[];
     nsith?: string | number | string[];
     toad?: number;
     cuts?: string[];
@@ -356,7 +357,7 @@ export class Identifier {
         const dig = state.d;
         const ridx = parseInt(state.s, 16) + 1;
         const wits = state.b;
-        let isith = state.nt;
+        let isith = kargs.isith ?? state.nt;
 
         let nsith = kargs.nsith ?? isith;
 

--- a/test/app/aiding.test.ts
+++ b/test/app/aiding.test.ts
@@ -599,6 +599,38 @@ describe('Aiding', () => {
             });
         });
 
+        it('Should use the given sign threshold over the previous next threshold', async () => {
+            const member1 = await createMockIdentifierState(randomUUID(), bran);
+            const member2 = await createMockIdentifierState(
+                randomUUID(),
+                randomPasscode()
+            );
+
+            const group = await createMockIdentifierState(randomUUID(), bran, {
+                algo: Algos.group,
+                mhab: member1,
+                isith: '2',
+                nsith: '1',
+                states: [member1.state, member2.state],
+                rstates: [member1.state, member2.state],
+            });
+            setGroupPriorNextDigests(group, [member1.state, member2.state]);
+
+            client.fetch.mockResolvedValueOnce(Response.json(group));
+            client.fetch.mockResolvedValueOnce(Response.json({}));
+            await client.identifiers().rotate(group.name, {
+                isith: '2',
+                nsith: '1',
+                states: [member1.state, member2.state],
+                rstates: [member1.state, member2.state],
+            });
+            const request = client.getLastMockRequest();
+            expect(request.body.rot).toMatchObject({
+                t: 'rot',
+                kt: '2',
+            });
+        });
+
         it('Uses prior group next digests for replacement rotation ondex', async () => {
             const member1 = await createMockIdentifierState(
                 randomUUID(),


### PR DESCRIPTION
The new signing threshold was pinned to the prior next threshold with no way to override it, so a group set up as 3 signing / 2 recovery came out of a rotation as 2 and 2. KERI does not require them to match, it only requires enough of the prior next keys to be exposed, so accept isith and keep the old value as the default.