### PR TITLE
Feat/card recovery

### DIFF
--- a/src/exports.ts
+++ b/src/exports.ts
@@ -5,6 +5,7 @@ export * from './keri/app/controller.ts';
 
 export * from './keri/app/aiding.ts';
 export * from './keri/app/clienting.ts';
+export * from './keri/app/externSigner.ts';
 export * from './keri/app/contacting.ts';
 export * from './keri/app/coring.ts';
 export * from './keri/app/credentialing.ts';

--- a/src/keri/app/clienting.ts
+++ b/src/keri/app/clienting.ts
@@ -376,6 +376,38 @@ export class SignifyClient {
     }
 
     /**
+     * Minimal retrofit of a recovery card onto an existing controller:
+     * single-key rotation committing the card digest as the new next while
+     * keeping the SAME bran (phone stays the signer). No aids, no per-AID
+     * re-encryption. See Controller.rotateExternalNext. Signs the PUT
+     * headers with the post-rotation signer (KERIA verifies inbound auth
+     * against post-rot k[0]).
+     */
+    async rotateExternalNext(
+        externalNdigs: string[],
+        opts: { sn?: number; priorDig?: string } = {}
+    ): Promise<Response> {
+        const data = this.controller.rotateExternalNext(externalNdigs, opts);
+        const path = '/agent/' + this.controller.pre;
+        const respVerfer =
+            this.agent?.verfer ?? this.controller.signer.verfer;
+        this.authn = new Authenticater(this.controller.signer, respVerfer);
+        const headers = new Headers();
+        headers.set('Signify-Resource', this.controller.pre);
+        headers.set(
+            HEADER_SIG_TIME,
+            new Date().toISOString().replace('Z', '000+00:00')
+        );
+        headers.set('Content-Type', 'application/json');
+        const signedHeaders = this.authn.sign(headers, 'PUT', path);
+        return await fetch(this.url + path, {
+            method: 'PUT',
+            body: JSON.stringify(data),
+            headers: signedHeaders,
+        });
+    }
+
+    /**
      * Retrofit a recovery card onto a wallet whose controller AID was
      * created without one. Re-uses the standard rotate plumbing (so the
      * agent sxlt and every per-AID sxlt are re-encrypted under the new

--- a/src/keri/app/clienting.ts
+++ b/src/keri/app/clienting.ts
@@ -376,6 +376,104 @@ export class SignifyClient {
     }
 
     /**
+     * Retrofit a recovery card onto a wallet whose controller AID was
+     * created without one. Re-uses the standard rotate plumbing (so the
+     * agent sxlt and every per-AID sxlt are re-encrypted under the new
+     * bran) but rewrites the rot's `n` to commit the card key. A future
+     * "Recover from card" tap can then sign a rotation against this
+     * prefix.
+     */
+    async rotateWithExternalNext(
+        nbran: string,
+        aids: string[],
+        nextOverride: string[]
+    ): Promise<Response> {
+        const data = this.controller.rotateWithExternalNext(
+            nbran,
+            aids,
+            nextOverride
+        );
+        return await fetch(this.url + '/agent/' + this.controller.pre, {
+            method: 'PUT',
+            body: JSON.stringify(data),
+            headers: {
+                'Content-Type': 'application/json',
+            },
+        });
+    }
+
+    /**
+     * Rotate the controller AID in the recovery-from-card path: the rot
+     * event is signed by an external key (the card-held previously
+     * committed next-key), the old sxlt blobs are decrypted via an
+     * external callback (the card via NFC + libsodium-off-card symmetric
+     * open), and new blobs are encrypted under nextCardPubQb64 so the
+     * card's chain keeps anchoring the next recovery.
+     *
+     * The caller is responsible for fetching the HabState of every managed
+     * AID before invoking this, since the controller (which normally pulls
+     * them) doesn't have a fresh authenticated session yet. Pass the array
+     * as `aids`.
+     */
+    async rotateForRecovery(
+        nbran: string,
+        cardPubQb64: string,
+        nextCardPubQb64: string,
+        aids: Array<any>,
+        decryptOld: (cipherQb64: string) => Promise<Uint8Array>,
+        signRot: (raw: Uint8Array) => Promise<Uint8Array>,
+        opts: {
+            recoveryFromIcp?: boolean;
+            sn?: number;
+            offCard?: boolean;
+            nextNdigs?: string[];
+            nsith?: string | string[];
+            aeidUnderNewBran?: boolean;
+        } = {}
+    ): Promise<Response> {
+        const body = await this.controller.rotateForRecovery(
+            nbran,
+            cardPubQb64,
+            nextCardPubQb64,
+            aids,
+            decryptOld,
+            signRot,
+            opts
+        );
+
+        // KERIA's PUT /agent/{caid} commits the rot to the controller hab
+        // BEFORE running authn.inbound, so the inbound signature is
+        // verified against the post-rotation k[0] (our new bran signer).
+        // Rebuild the Authenticater with the freshly mutated signer and
+        // sign the request headers manually (we can't use this.fetch
+        // because that path also verifies the response signature, and here
+        // we don't care about the agent's reply envelope).
+        //
+        // The Authenticater's verfer is only consulted by verify(), which
+        // we never call here, so passing the controller signer's own verfer
+        // is safe even when this.agent is still null (fresh-phone recovery
+        // path, pre-connect).
+        const respVerfer =
+            this.agent?.verfer ?? this.controller.signer.verfer;
+        this.authn = new Authenticater(this.controller.signer, respVerfer);
+        const path = '/agent/' + this.controller.pre;
+        const headers = new Headers();
+        headers.set('Signify-Resource', this.controller.pre);
+        headers.set(
+            HEADER_SIG_TIME,
+            new Date().toISOString().replace('Z', '000+00:00')
+        );
+        headers.set('Content-Type', 'application/json');
+        const signedHeaders = this.authn.sign(headers, 'PUT', path);
+
+        return await fetch(this.url + path, {
+            method: 'PUT',
+            body: JSON.stringify(body),
+            headers: signedHeaders,
+        });
+    }
+
+    /**
      * Get identifiers resource
      * @returns {Identifier}
      */

--- a/src/keri/app/clienting.ts
+++ b/src/keri/app/clienting.ts
@@ -527,6 +527,90 @@ export class SignifyClient {
     }
 
     /**
+     * Card-backed -> seed via two clean single-key rotations (see
+     * Controller.rotateOffCardToSeed). Submits rot1 (reveal the card key)
+     * then rot2 (reveal the new bran key). Both PUTs are signed with the
+     * post-rotation bran signer:
+     *  - rot1's PUT 403s (KERIA validates headers against post-rot1 k[0]=card,
+     *    not our bran signer) but the event still lands, because on_put
+     *    applies the rot BEFORE checking auth. rot1's sxlt/keys are no-ops so
+     *    skipping the post-auth update is harmless.
+     *  - between the two we re-read KERIA and confirm the controller actually
+     *    moved onto the card key. If not, we abort BEFORE rot2 so a bad rot1
+     *    can never leave the controller half-rotated.
+     *  - rot2's PUT authenticates (post-rot2 k[0]=bran=our signer) and KERIA
+     *    applies the new sxlt + per-AID re-key.
+     */
+    async rotateOffCardToSeed(
+        nbran: string,
+        cardCurPubQb64: string,
+        aids: Array<any>,
+        decryptOld: (cipherQb64: string) => Promise<Uint8Array>,
+        signRot: (raw: Uint8Array) => Promise<Uint8Array>,
+        opts: { sn?: number; priorDig?: string } = {}
+    ): Promise<Response> {
+        const body = await this.controller.rotateOffCardToSeed(
+            nbran,
+            cardCurPubQb64,
+            aids,
+            decryptOld,
+            signRot,
+            opts
+        );
+
+        const path = '/agent/' + this.controller.pre;
+        const signPut = async (data: Record<string, unknown>) => {
+            const respVerfer =
+                this.agent?.verfer ?? this.controller.signer.verfer;
+            this.authn = new Authenticater(
+                this.controller.signer,
+                respVerfer
+            );
+            const headers = new Headers();
+            headers.set('Signify-Resource', this.controller.pre);
+            headers.set(
+                HEADER_SIG_TIME,
+                new Date().toISOString().replace('Z', '000+00:00')
+            );
+            headers.set('Content-Type', 'application/json');
+            const signed = this.authn.sign(headers, 'PUT', path);
+            return await fetch(this.url + path, {
+                method: 'PUT',
+                body: JSON.stringify(data),
+                headers: signed,
+            });
+        };
+
+        // rot1: lands even though the PUT 403s (see doc above).
+        await signPut({
+            rot: body.rot1,
+            sigs: body.sigs1,
+            sxlt: body.sxlt1,
+            keys: body.keys1,
+        });
+
+        // Guard: confirm rot1 landed (controller now on the card key) before
+        // revealing the bran. Never send rot2 onto an unexpected state.
+        const stateRes = await fetch(this.url + path);
+        const st = await stateRes.json();
+        const k0 = st?.controller?.state?.k?.[0];
+        if (k0 !== cardCurPubQb64) {
+            throw new Error(
+                `rotateOffCardToSeed: rot1 did not land (KERIA k[0]=${k0}, ` +
+                    `expected the card key). Aborting before rot2.`
+            );
+        }
+
+        // rot2: authenticates and applies sxlt2 + the per-AID re-key.
+        return await signPut({
+            rot: body.rot2,
+            sigs: body.sigs2,
+            sxlt: body.sxlt2,
+            keys: body.keys2,
+        });
+    }
+
+    /**
      * Get identifiers resource
      * @returns {Identifier}
      */

--- a/src/keri/app/clienting.ts
+++ b/src/keri/app/clienting.ts
@@ -395,12 +395,31 @@ export class SignifyClient {
             nextOverride,
             opts
         );
-        return await fetch(this.url + '/agent/' + this.controller.pre, {
+
+        // KERIA commits the rot to the controller hab BEFORE running
+        // authn.inbound, so it verifies the inbound signature against the
+        // post-rotation k[0] (our new bran signer). Sign the request with
+        // the freshly mutated controller signer, exactly like
+        // rotateForRecovery. WITHOUT this the rot is applied and THEN the
+        // request 403s, leaving the wallet's controller key rotated away on
+        // KERIA while the caller (thinking it failed) never persists the
+        // new bran -> bricked controller.
+        const path = '/agent/' + this.controller.pre;
+        const respVerfer =
+            this.agent?.verfer ?? this.controller.signer.verfer;
+        this.authn = new Authenticater(this.controller.signer, respVerfer);
+        const headers = new Headers();
+        headers.set('Signify-Resource', this.controller.pre);
+        headers.set(
+            HEADER_SIG_TIME,
+            new Date().toISOString().replace('Z', '000+00:00')
+        );
+        headers.set('Content-Type', 'application/json');
+        const signedHeaders = this.authn.sign(headers, 'PUT', path);
+        return await fetch(this.url + path, {
             method: 'PUT',
             body: JSON.stringify(data),
-            headers: {
-                'Content-Type': 'application/json',
-            },
+            headers: signedHeaders,
         });
     }
 

--- a/src/keri/app/clienting.ts
+++ b/src/keri/app/clienting.ts
@@ -386,12 +386,14 @@ export class SignifyClient {
     async rotateWithExternalNext(
         nbran: string,
         aids: string[],
-        nextOverride: string[]
+        nextOverride: string[],
+        opts: { sn?: number; priorDig?: string } = {}
     ): Promise<Response> {
         const data = this.controller.rotateWithExternalNext(
             nbran,
             aids,
-            nextOverride
+            nextOverride,
+            opts
         );
         return await fetch(this.url + '/agent/' + this.controller.pre, {
             method: 'PUT',

--- a/src/keri/app/controller.ts
+++ b/src/keri/app/controller.ts
@@ -999,6 +999,11 @@ export class Controller {
         }
 
         // Commit local state to rot2 (the final, phone-controlled state).
+        // Fresh bran: the current key is nb0 (ridx 0) and the committed next
+        // is nb1 (ridx 1). ridx tracks the CURRENT key's index, so it RESETS
+        // to 0 here — NOT +=1. Getting this wrong makes the next
+        // rotateExternalNext derive create(ridx+1) at the wrong index and
+        // reveal a key KERIA never committed (500 on the following backup).
         this.bran = newBranQb64;
         this.salter = newSalter;
         this.signer = nb0;
@@ -1006,7 +1011,7 @@ export class Controller {
         this.keys = [nb0.verfer.qb64];
         this.ndigs = [nb1Digest];
         this.serder = rot2;
-        this.ridx += 1;
+        this.ridx = 0;
 
         return {
             rot1: rot1.sad,

--- a/src/keri/app/controller.ts
+++ b/src/keri/app/controller.ts
@@ -852,6 +852,175 @@ export class Controller {
     }
 
     /**
+     * Rotate the controller from card-backed back to a fresh seed (bran) in
+     * TWO clean single-key rotations, instead of the dual-key reveal
+     * rotateForRecovery uses (only valid as a superseding recovery, which
+     * mid-KEL leaves a 2-key controller the single-key Authenticater can't
+     * drive). Prior state after a backup is k=[bran], n=[card]:
+     *
+     *   rot1: reveal k=[card] (matches the prior n=[card]), commit
+     *         n=[digest(nb0)]. Signed by the card (the revealed next).
+     *   rot2: reveal k=[nb0] (matches rot1.n), commit n=[digest(nb1)].
+     *         Signed by nb0 (the new bran current, phone-held).
+     *
+     * End state: k=[nb0] single, next bran-derived -> phone controls,
+     * seed-recoverable, and the next backup's rotateExternalNext chains
+     * cleanly. Returns BOTH events; the caller PUTs rot1 then rot2. rot1's
+     * PUT must carry card-signed auth headers (KERIA validates headers
+     * against post-rot1 k[0]=card); rot2's headers are nb0-signed.
+     */
+    async rotateOffCardToSeed(
+        nbran: string,
+        cardCurPubQb64: string,
+        aids: Array<any>,
+        decryptOld: (cipherQb64: string) => Promise<Uint8Array>,
+        signRot: (raw: Uint8Array) => Promise<Uint8Array>,
+        opts: { sn?: number; priorDig?: string } = {}
+    ): Promise<{
+        rot1: Record<string, unknown>;
+        sigs1: string[];
+        sxlt1: string;
+        keys1: Record<string, any>;
+        rot2: Record<string, unknown>;
+        sigs2: string[];
+        sxlt2: string;
+        keys2: Record<string, any>;
+    }> {
+        // New bran signers: nb0 = current after rot2, nb1 = its next.
+        const newBranQb64 = MtrDex.Salt_128 + 'A' + nbran.substring(0, 21);
+        const newSalter = new Salter({ qb64: newBranQb64, tier: this.tier });
+        const newCreator = new SaltyCreator(
+            newSalter.qb64,
+            this.tier,
+            this.stem
+        );
+        const nb0 = newCreator
+            .create(undefined, 1, MtrDex.Ed25519_Seed, true, 0, 0, 0, false)
+            .signers.pop()!;
+        const nb1 = newCreator
+            .create(undefined, 1, MtrDex.Ed25519_Seed, true, 0, 1, 0, false)
+            .signers.pop()!;
+
+        // rot1: reveal the card key as the sole new current. Its digest is
+        // already the prior n (from the backup), so a plain single-key rot.
+        const cardVerfer = new Verfer({ qb64: cardCurPubQb64 });
+        const priorDig1 = opts.priorDig ?? (this.serder.sad['d'] as string);
+        const sn1 =
+            opts.sn ??
+            new CesrNumber({}, this.serder.sad['s'] as string).num + 1;
+        const nb0Digest = new Diger(
+            { code: MtrDex.Blake3_256 },
+            nb0.verfer.qb64b
+        ).qb64;
+        const rot1 = rotate({
+            pre: this.pre,
+            keys: [cardVerfer.qb64],
+            dig: priorDig1,
+            sn: sn1,
+            isith: '1',
+            nsith: '1',
+            ndigs: [nb0Digest],
+            wits: this.wits,
+            toad: this.toad,
+        });
+        const card1Raw = await signRot(b(rot1.raw));
+        const sigs1 = [
+            new Siger({
+                raw: card1Raw,
+                code: IdrDex.Ed25519_Sig,
+                index: 0,
+            }).qb64,
+        ];
+        // rot1 doesn't touch the bran; keep the current sxlt (old bran under
+        // old aeid) so KERIA's manager stays consistent through the transient
+        // card-current step. No per-AID re-key here.
+        const oldAeidSigner = this.salter.signer(undefined, false);
+        const sxlt1 = new Encrypter({}, b(oldAeidSigner.verfer.qb64))
+            .encrypt(b(this.bran))
+            .qb64;
+
+        // rot2: reveal nb0 (matches rot1.n) as the sole new current, commit
+        // nb1 as next. nb0 is phone-held so the phone signs it.
+        const priorDig2 = rot1.sad['d'] as string;
+        const sn2 = sn1 + 1;
+        const nb1Digest = new Diger(
+            { code: MtrDex.Blake3_256 },
+            nb1.verfer.qb64b
+        ).qb64;
+        const rot2 = rotate({
+            pre: this.pre,
+            keys: [nb0.verfer.qb64],
+            dig: priorDig2,
+            sn: sn2,
+            isith: '1',
+            nsith: '1',
+            ndigs: [nb1Digest],
+            wits: this.wits,
+            toad: this.toad,
+        });
+        const sigs2 = [nb0.sign(b(rot2.raw), 0).qb64];
+
+        // rot2 switches the bran to nbran: re-key the aeid like
+        // rotateForRecovery does (proven by the onboarding-recovery path).
+        const newBranAeidSigner = newSalter.signer(
+            MtrDex.Ed25519_Seed,
+            true,
+            '',
+            this.tier
+        );
+        const encrypter = new Encrypter({}, b(newBranAeidSigner.verfer.qb64));
+        const sxlt2 = encrypter.encrypt(b(newBranQb64)).qb64;
+        const keys2: Record<string, any> = {};
+        for (const aid of aids) {
+            const pre = aid['prefix'] as string;
+            if ('salty' in aid) {
+                const plaintext = await decryptOld(
+                    aid['salty']['sxlt'] as string
+                );
+                keys2[pre] = { sxlt: encrypter.encrypt(plaintext).qb64 };
+            } else if ('randy' in aid) {
+                const randy = aid['randy'];
+                const oldPrxs = (randy['prxs'] ?? []) as string[];
+                const oldNxts = (randy['nxts'] ?? []) as string[];
+                const newPrxs: string[] = [];
+                const newNxts: string[] = [];
+                for (const prx of oldPrxs) {
+                    newPrxs.push(
+                        encrypter.encrypt(await decryptOld(prx)).qb64
+                    );
+                }
+                for (const nxt of oldNxts) {
+                    newNxts.push(
+                        encrypter.encrypt(await decryptOld(nxt)).qb64
+                    );
+                }
+                keys2[pre] = { prxs: newPrxs, nxts: newNxts };
+            }
+        }
+
+        // Commit local state to rot2 (the final, phone-controlled state).
+        this.bran = newBranQb64;
+        this.salter = newSalter;
+        this.signer = nb0;
+        this.nsigner = nb1;
+        this.keys = [nb0.verfer.qb64];
+        this.ndigs = [nb1Digest];
+        this.serder = rot2;
+        this.ridx += 1;
+
+        return {
+            rot1: rot1.sad,
+            sigs1,
+            sxlt1,
+            keys1: {},
+            rot2: rot2.sad,
+            sigs2,
+            sxlt2,
+            keys2,
+        };
+    }
+
+    /**
      * Replace the inception event's next-key commitment with externally
      * provided digests and rebuild this.serder. Used by hosts that want the
      * controller AID to be rotatable via an external signer (e.g. a hardware

--- a/src/keri/app/controller.ts
+++ b/src/keri/app/controller.ts
@@ -705,7 +705,17 @@ export class Controller {
     rotateWithExternalNext(
         bran: string,
         aids: Array<any>,
-        nextOverride: string[]
+        nextOverride: string[],
+        opts: {
+            // Explicit sn/prior for the rebuilt rot. The standard rotate
+            // derives them from this.serder, which after connect is the
+            // establishment event; if the KEL advanced past it with an
+            // anchoring ixn (agent delegation seal) the derived rot lands
+            // ON that ixn's sn and KERIA rejects it as a bad recovery
+            // attempt. Same override pair rotateForRecovery already takes.
+            sn?: number;
+            priorDig?: string;
+        } = {}
     ): Record<string, unknown> {
         if (!nextOverride || nextOverride.length === 0) {
             throw new Error('rotateWithExternalNext: nextOverride required');
@@ -734,13 +744,16 @@ export class Controller {
         // Run the standard rotate so re-encryption side effects happen.
         const body: any = this.rotate(bran, aids);
 
-        // Rebuild rot with the override ndigs but the SAME dual-key shape,
-        // threshold AND sn the standard rotate emitted.
-        const rebuiltSn = new CesrNumber({}, body.rot.s as string).num;
+        // Rebuild rot with the override ndigs but the SAME dual-key shape
+        // and threshold the standard rotate emitted. sn/prior come from
+        // opts when the caller knows the KEL's true head (see opts docs),
+        // else fall back to what the standard rotate derived.
+        const rebuiltSn =
+            opts.sn ?? new CesrNumber({}, body.rot.s as string).num;
         const rebuilt = rotate({
             pre: this.pre,
             keys: this.keys,
-            dig: body.rot.p,
+            dig: opts.priorDig ?? body.rot.p,
             sn: rebuiltSn,
             isith: body.rot.kt,
             nsith: '1',

--- a/src/keri/app/controller.ts
+++ b/src/keri/app/controller.ts
@@ -514,6 +514,10 @@ export class Controller {
             // (wallet stays card-bound). The bran is recoverable
             // via the on-card escrow blob.
             aeidUnderNewBran?: boolean;
+            // Prior event said to chain the rot to. Lets the caller rotate
+            // AFTER an anchoring ixn (a profile's delegation seal) instead of
+            // superseding it from the establishment event. Pair with opts.sn.
+            priorDig?: string;
         } = {}
     ): Promise<{
         rot: Record<string, unknown>;
@@ -586,9 +590,11 @@ export class Controller {
         // against the icp's original n, skipping any intermediate event an
         // attacker may have inserted. The disputed sn must still be greater
         // than the latest seen sn; the caller supplies it via opts.sn.
-        const priorDig = opts.recoveryFromIcp
-            ? this.pre
-            : (this.serder.sad['d'] as string);
+        const priorDig =
+            opts.priorDig ??
+            (opts.recoveryFromIcp
+                ? this.pre
+                : (this.serder.sad['d'] as string));
         const nextSn =
             opts.sn ?? new CesrNumber({}, this.serder.sad['s']).num + 1;
         const rot = rotate({

--- a/src/keri/app/controller.ts
+++ b/src/keri/app/controller.ts
@@ -771,6 +771,87 @@ export class Controller {
     }
 
     /**
+     * Commit an external next-key digest (a hardware recovery card's pub) as
+     * the controller's new next with a MINIMAL single-key rotation that keeps
+     * the SAME bran. The rotation-time twin of {@link setExternalNext}: it
+     * reveals the pre-committed bran next-key as the new current (so the phone
+     * keeps signing tap-free), sets n to the external digest, and leaves the
+     * bran untouched. Because the bran (hence the per-AID sxlt aeid) doesn't
+     * change there is nothing to re-encrypt: keys is empty and sxlt is the
+     * current bran re-wrapped under the unchanged aeid.
+     *
+     * Unlike {@link rotateWithExternalNext} this does NOT run the passcode
+     * rotation machinery (no new bran, no dual-key reveal, no per-AID
+     * re-encryption), so it needs no aids or aid HabStates.
+     *
+     * opts.sn/priorDig chain the rot after the KEL's true head (a profile's
+     * agent-delegation ixn), same as {@link rotateForRecovery}.
+     */
+    rotateExternalNext(
+        externalNdigs: string[],
+        opts: { sn?: number; priorDig?: string } = {}
+    ): Record<string, unknown> {
+        if (!externalNdigs || externalNdigs.length === 0) {
+            throw new Error('rotateExternalNext: externalNdigs required');
+        }
+
+        // The pre-committed next is the bran signer at ridx+1. Revealing it as
+        // the new current is a plain single-key rotation the phone can sign.
+        const creator = new SaltyCreator(
+            this.salter.qb64,
+            this.tier,
+            this.stem
+        );
+        const newCurrent = creator
+            .create(
+                undefined,
+                1,
+                MtrDex.Ed25519_Seed,
+                true,
+                0,
+                this.ridx + 1,
+                0,
+                false
+            )
+            .signers.pop()!;
+        const newKeys = [newCurrent.verfer.qb64];
+
+        const priorDig = opts.priorDig ?? (this.serder.sad['d'] as string);
+        const sn =
+            opts.sn ??
+            new CesrNumber({}, this.serder.sad['s'] as string).num + 1;
+        const rot = rotate({
+            pre: this.pre,
+            keys: newKeys,
+            dig: priorDig,
+            sn,
+            isith: '1',
+            nsith: '1',
+            ndigs: externalNdigs,
+            wits: this.wits,
+            toad: this.toad,
+        });
+        const sigs = [newCurrent.sign(b(rot.raw), 0).qb64];
+
+        // Bran unchanged -> aeid unchanged -> sxlt is the same bran re-wrapped
+        // and no per-AID salt needs re-keying.
+        const aeidSigner = this.salter.signer(undefined, false);
+        const encrypter = new Encrypter({}, b(aeidSigner.verfer.qb64));
+        const sxlt = encrypter.encrypt(b(this.bran)).qb64;
+
+        // Commit the new state locally. The next is the card, so the local
+        // bran-derived nsigner is meaningless.
+        this.signer = newCurrent;
+        this.keys = newKeys;
+        this.ndigs = externalNdigs;
+        this.nsigner = undefined;
+        this.serder = rot;
+        this.ridx += 1;
+
+        return { rot: rot.sad, sigs, sxlt, keys: {} };
+    }
+
+    /**
      * Replace the inception event's next-key commitment with externally
      * provided digests and rebuild this.serder. Used by hosts that want the
      * controller AID to be rotatable via an external signer (e.g. a hardware

--- a/src/keri/app/controller.ts
+++ b/src/keri/app/controller.ts
@@ -12,6 +12,8 @@ import { Decrypter } from '../core/decrypter.ts';
 import { Cipher } from '../core/cipher.ts';
 import { Seqner } from '../core/seqner.ts';
 import { CesrNumber } from '../core/number.ts';
+import { Siger } from '../core/siger.ts';
+import { IdrDex } from '../core/indexer.ts';
 
 /**
  * Agent is a custodial entity that can be used in conjuntion with a local Client to establish the
@@ -138,6 +140,18 @@ export class Controller {
      * Digests of the next public keys formatted in fully-qualified Base64.
      */
     public ndigs: string[];
+    /**
+     * Witness prefixes for this controller's establishment events. Set
+     * via setExternalNext (or the constructor) before .boot() to thread
+     * receipts through the chosen witness pool, then preserved across
+     * rotations so rotateForRecovery emits a rot with the right `bt`.
+     */
+    public wits: string[] = [];
+    /**
+     * Threshold of accountable duplicity (numeric). Mirrors the prior
+     * establishment event so the recovery rot's `bt` keeps matching.
+     */
+    public toad: number = 0;
 
     /**
      * Creates a Signify Controller starting at key index 0 that generates keys in
@@ -210,18 +224,39 @@ export class Controller {
                 .qb64,
         ];
 
-        if (state == null || state['ee']['s'] == 0) {
+        if (state == null) {
             this.serder = incept({
                 keys: this.keys,
                 isith: '1',
                 nsith: '1',
                 ndigs: this.ndigs,
                 code: MtrDex.Blake3_256,
-                toad: '0',
-                wits: [],
+                toad: this.toad,
+                wits: this.wits,
             });
         } else {
+            // Always mirror the establishment event KERIA already has,
+            // including the inception (s==0) case. Rebuilding a fresh
+            // local incept here would lose any external override applied
+            // before boot (e.g. setExternalNext for the BioCard recovery
+            // flow, where n[0] is committed to the card pub instead of
+            // the bran-derived next-key).
             this.serder = new Serder(state['ee']);
+            if (state['ee']['n']) {
+                this.ndigs = state['ee']['n'];
+            }
+            // Restore wits/toad from KERIA's current key state if it
+            // exposed them. The rot's `bt` chains to the prior `b` set,
+            // so rotateForRecovery needs these to survive a connect.
+            const kstate = state['state'];
+            if (kstate && Array.isArray(kstate['b'])) {
+                this.wits = kstate['b'];
+            }
+            if (kstate && kstate['bt'] !== undefined) {
+                const btRaw = kstate['bt'];
+                this.toad =
+                    typeof btRaw === 'string' ? parseInt(btRaw, 16) : btRaw;
+            }
         }
     }
 
@@ -429,5 +464,336 @@ export class Controller {
         const cipher = new Cipher({ qb64: enc });
         const dnxt = decrypter.decrypt(null, cipher).qb64;
         return encrypter.encrypt(b(dnxt)).qb64;
+    }
+
+    /**
+     * Build a controller rotation event whose new current key is
+     * bran-derived (a brand new bran on a brand new phone) but whose
+     * signing comes from an external signer (the BioCard) holding the
+     * previously committed next-key.
+     *
+     * This is the recovery-from-card flow. Standard {@link rotate} can't
+     * cover it because:
+     *   - The old bran is gone (phone was lost)
+     *   - The signature must be produced by the previously-committed-next
+     *     key, which lives on the card
+     *   - The old AID sxlt blobs are encrypted under that same card-held
+     *     key, so the card must decrypt them via X25519 ECDH callback
+     *   - The new sxlt blobs must be encrypted under the NEXT card pub
+     *     (chosen by the host so the chain keeps going for the next
+     *     recovery)
+     *
+     * Returns the body ready to PUT against /agent/{caid} and mutates
+     * this.bran, this.signer, this.nsigner, this.serder and this.ridx to
+     * reflect the rotated state.
+     */
+    async rotateForRecovery(
+        nbran: string,
+        cardPubQb64: string,
+        nextCardPubQb64: string,
+        aids: Array<any>,
+        decryptOld: (cipherQb64: string) => Promise<Uint8Array>,
+        signRot: (raw: Uint8Array) => Promise<Uint8Array>,
+        opts: {
+            recoveryFromIcp?: boolean;
+            sn?: number;
+            offCard?: boolean;
+            // Override the rot's `n` commitment. Lets the caller
+            // build a multi-card next, swap one card for a different
+            // one entirely, or attach an explicit threshold without
+            // forcing a follow-up signify-ts API change. When set,
+            // `nextCardPubQb64` is ignored for the n[] computation
+            // (it still feeds the per-AID encrypter so the wallet
+            // can decrypt later via the new chip slot).
+            nextNdigs?: string[];
+            // Threshold for the new n[] commitment. Defaults to '1'.
+            nsith?: string | string[];
+            // Model B: re-key the sxlt encrypter to the new bran's
+            // salter signer so normal signing stays bran-based and
+            // tap-free, while n[] still commits the card next-pub
+            // (wallet stays card-bound). The bran is recoverable
+            // via the on-card escrow blob.
+            aeidUnderNewBran?: boolean;
+        } = {}
+    ): Promise<{
+        rot: Record<string, unknown>;
+        sigs: string[];
+        sxlt: string;
+        keys: Record<string, any>;
+    }> {
+        // 1. Derive the new current signer from nbran.
+        const newBranQb64 = MtrDex.Salt_128 + 'A' + nbran.substring(0, 21);
+        const newSalter = new Salter({ qb64: newBranQb64, tier: this.tier });
+        const newCreator = new SaltyCreator(
+            newSalter.qb64,
+            this.tier,
+            this.stem
+        );
+        const newSigner = newCreator
+            .create(undefined, 1, MtrDex.Ed25519_Seed, true, 0, 0, 0, false)
+            .signers.pop();
+
+        // offCard variant: also derive the next bran-side signer so the
+        // rot's n[] commits a bran-derived digest instead of the next
+        // card pub. After the rotation the controller's next-key
+        // commitment is fully back on the phone.
+        const newNsigner = opts.offCard
+            ? newCreator
+                  .create(
+                      undefined,
+                      1,
+                      MtrDex.Ed25519_Seed,
+                      true,
+                      0,
+                      1,
+                      0,
+                      false
+                  )
+                  .signers.pop()
+            : undefined;
+
+        // 2. Build the rot's n[] commitment.
+        let ndigs: string[];
+        const nsith: string | string[] = opts.nsith ?? '1';
+        if (opts.nextNdigs && opts.nextNdigs.length > 0) {
+            ndigs = opts.nextNdigs;
+        } else if (opts.offCard) {
+            ndigs = [
+                new Diger(
+                    { code: MtrDex.Blake3_256 },
+                    newNsigner!.verfer.qb64b
+                ).qb64,
+            ];
+        } else {
+            const nextCardVerfer = new Verfer({ qb64: nextCardPubQb64 });
+            ndigs = [
+                new Diger(
+                    { code: MtrDex.Blake3_256 },
+                    nextCardVerfer.qb64b
+                ).qb64,
+            ];
+        }
+
+        // 3. Build the dual-key rot serder. The card's pub (the
+        // previously-committed next) must appear in k as the revealed old
+        // next, alongside the new bran-derived current. Weighted threshold
+        // [new=1, old=0]: new current carries signing weight, old next is
+        // revealed for verification only.
+        const cardVerfer = new Verfer({ qb64: cardPubQb64 });
+        const newKeys = [newSigner!.verfer.qb64, cardVerfer.qb64];
+        // recoveryFromIcp overrides the prior dig with the controller's own
+        // inception said (= controller.pre) so KERIA validates the rot's k
+        // against the icp's original n, skipping any intermediate event an
+        // attacker may have inserted. The disputed sn must still be greater
+        // than the latest seen sn; the caller supplies it via opts.sn.
+        const priorDig = opts.recoveryFromIcp
+            ? this.pre
+            : (this.serder.sad['d'] as string);
+        const nextSn =
+            opts.sn ?? new CesrNumber({}, this.serder.sad['s']).num + 1;
+        const rot = rotate({
+            pre: this.pre,
+            keys: newKeys,
+            dig: priorDig,
+            sn: nextSn,
+            isith: ['1', '0'],
+            nsith,
+            ndigs,
+            wits: this.wits,
+            toad: this.toad,
+        });
+
+        // 4. Two sigs: card at index 1 ondex 0 (revealed old next), new
+        // bran at index 0 (new current).
+        const cardSigRaw = await signRot(b(rot.raw));
+        const cardSiger = new Siger({
+            raw: cardSigRaw,
+            code: IdrDex.Ed25519_Big_Sig,
+            index: 1,
+            ondex: 0,
+        });
+        const newSiger = newSigner!.sign(b(rot.raw), 0);
+        const sigs = [newSiger.qb64, cardSiger.qb64];
+
+        // 5. Encrypter for the new sxlt blobs.
+        const newBranAeidSigner = newSalter.signer(
+            MtrDex.Ed25519_Seed,
+            true,
+            '',
+            this.tier
+        );
+        const encrypter =
+            opts.offCard || opts.aeidUnderNewBran
+                ? new Encrypter({}, b(newBranAeidSigner.verfer.qb64))
+                : new Encrypter({}, b(nextCardPubQb64));
+
+        // 6. New top-level sxlt: encrypted new bran.
+        const sxlt = encrypter.encrypt(b(newBranQb64)).qb64;
+
+        // 7. Per-AID re-encryption.
+        const keys: Record<string, any> = {};
+        for (const aid of aids) {
+            const pre = aid['prefix'] as string;
+            if ('salty' in aid) {
+                const salty = aid['salty'];
+                // The card decrypts the OLD sxlt and returns plaintext
+                // bytes. The host wraps card.ecdh() + libsodium symmetric
+                // open in this callback.
+                const plaintext = await decryptOld(salty['sxlt'] as string);
+                const newSxlt = encrypter.encrypt(plaintext).qb64;
+                keys[pre] = { sxlt: newSxlt };
+            } else if ('randy' in aid) {
+                // Randy AIDs store each signing/next priv encrypted
+                // independently. Decrypt every blob via the card and
+                // re-encrypt under the new next-card pub.
+                const randy = aid['randy'];
+                const oldPrxs = (randy['prxs'] ?? []) as string[];
+                const oldNxts = (randy['nxts'] ?? []) as string[];
+                const newPrxs: string[] = [];
+                const newNxts: string[] = [];
+                for (const prx of oldPrxs) {
+                    const plaintext = await decryptOld(prx);
+                    newPrxs.push(encrypter.encrypt(plaintext).qb64);
+                }
+                for (const nxt of oldNxts) {
+                    const plaintext = await decryptOld(nxt);
+                    newNxts.push(encrypter.encrypt(plaintext).qb64);
+                }
+                keys[pre] = { prxs: newPrxs, nxts: newNxts };
+            }
+            // extern AIDs: nothing to re-encrypt; KERIA keeps the prefix
+            // store and the extern_type via the ExternKeeper patch.
+            // group AIDs: their material lives in member habs.
+        }
+
+        // 8. Commit the new state on this Controller.
+        this.bran = newBranQb64;
+        this.salter = newSalter;
+        this.signer = newSigner;
+        // Card path: the next is the card itself, so the local nsigner is
+        // meaningless. offCard path: restore the bran-derived nsigner so
+        // future standard rotate() calls can chain.
+        this.nsigner = opts.offCard ? newNsigner : undefined;
+        this.keys = newKeys;
+        this.ndigs = ndigs;
+        this.serder = rot;
+        this.ridx += 1;
+
+        return {
+            rot: rot.sad,
+            sigs,
+            sxlt,
+            keys,
+        };
+    }
+
+    /**
+     * Retrofit a recovery card onto an EXISTING wallet whose controller
+     * AID was not provisioned with an external next-key.
+     *
+     * Runs the standard {@link rotate} to advance the controller bran and
+     * re-encrypt every AID's sxlt, then rebuilds the rot serder so its `n`
+     * array is the host-supplied digest array (the digest of
+     * `card.slot0.pub_0`) instead of the bran-derived next.
+     */
+    rotateWithExternalNext(
+        bran: string,
+        aids: Array<any>,
+        nextOverride: string[]
+    ): Record<string, unknown> {
+        if (!nextOverride || nextOverride.length === 0) {
+            throw new Error('rotateWithExternalNext: nextOverride required');
+        }
+        // Re-derive the OLD next signer BEFORE calling rotate(): it
+        // overwrites this.salter. The OLD next is the second key in the
+        // dual-key rotation shape and signs at index 1 ondex 0.
+        const oldCreator = new SaltyCreator(
+            this.salter.qb64,
+            this.tier,
+            this.stem
+        );
+        const oldNextSigner = oldCreator
+            .create(
+                undefined,
+                1,
+                MtrDex.Ed25519_Seed,
+                true,
+                0,
+                this.ridx + 1,
+                0,
+                false
+            )
+            .signers.pop();
+
+        // Run the standard rotate so re-encryption side effects happen.
+        const body: any = this.rotate(bran, aids);
+
+        // Rebuild rot with the override ndigs but the SAME dual-key shape,
+        // threshold AND sn the standard rotate emitted.
+        const rebuiltSn = new CesrNumber({}, body.rot.s as string).num;
+        const rebuilt = rotate({
+            pre: this.pre,
+            keys: this.keys,
+            dig: body.rot.p,
+            sn: rebuiltSn,
+            isith: body.rot.kt,
+            nsith: '1',
+            ndigs: nextOverride,
+        });
+
+        const sigs = [
+            oldNextSigner!.sign(b(rebuilt.raw), 1, false, 0).qb64,
+            this.signer.sign(b(rebuilt.raw), 0).qb64,
+        ];
+
+        this.ndigs = nextOverride;
+        this.serder = rebuilt;
+        return { ...body, rot: rebuilt.sad, sigs };
+    }
+
+    /**
+     * Replace the inception event's next-key commitment with externally
+     * provided digests and rebuild this.serder. Used by hosts that want the
+     * controller AID to be rotatable via an external signer (e.g. a hardware
+     * recovery card whose key was not derived from the controller bran).
+     *
+     * Must be called before .boot() and only when ridx == 0 (no rotations
+     * yet). For rotations the next commit is set inside .rotate() so this
+     * setter has no effect there.
+     */
+    setExternalNext(
+        ndigs: string[],
+        opts: { wits?: string[]; toad?: number } = {}
+    ) {
+        if (this.ridx !== 0) {
+            throw new Error(
+                'setExternalNext: controller has already rotated, ' +
+                    'override only valid at inception'
+            );
+        }
+        if (!ndigs || ndigs.length === 0) {
+            throw new Error('setExternalNext: ndigs required');
+        }
+        this.ndigs = ndigs;
+        if (opts.wits !== undefined) {
+            this.wits = opts.wits;
+        }
+        if (opts.toad !== undefined) {
+            this.toad = opts.toad;
+        } else if (opts.wits !== undefined) {
+            this.toad =
+                opts.wits.length === 0
+                    ? 0
+                    : Math.max(1, Math.ceil((opts.wits.length * 2) / 3));
+        }
+        this.serder = incept({
+            keys: this.keys,
+            isith: '1',
+            nsith: '1',
+            ndigs: this.ndigs,
+            code: MtrDex.Blake3_256,
+            toad: this.toad,
+            wits: this.wits,
+        });
     }
 }

--- a/src/keri/app/externSigner.ts
+++ b/src/keri/app/externSigner.ts
@@ -1,0 +1,144 @@
+import { Algos } from '../core/manager.ts';
+import { Signer } from '../core/signer.ts';
+import { Verfer } from '../core/verfer.ts';
+import { Diger } from '../core/diger.ts';
+import { Siger } from '../core/siger.ts';
+import { Cigar } from '../core/cigar.ts';
+import { MtrDex } from '../core/matter.ts';
+import { IdrDex } from '../core/indexer.ts';
+import {
+    IdentifierManager,
+    IdentifierManagerResult,
+    SignResult,
+} from '../core/keeping.ts';
+import { KeyState } from '../core/keyState.ts';
+
+export interface IExternalSigner {
+    sign(msg: Uint8Array): Promise<Uint8Array>;
+    pubKey(): Promise<Uint8Array>;
+    nextPubKey(): Promise<Uint8Array>;
+    rotate(): Promise<void>;
+}
+
+export class ExternSignerModule implements IdentifierManager {
+    algo: Algos = Algos.extern;
+    signers: Signer[] = [];
+
+    // Registry of live IExternalSigner instances keyed by AID prefix.
+    // KERIA cannot serialise a signer reference, so the HabState returned by
+    // GET /identifiers/{pre} only carries {extern_type, pidx}. When signify-ts
+    // rebuilds the manager from that HabState (e.g. inside addEndRole or any
+    // other signing path), there's no signer in kargs. Hosts that own the
+    // signer (e.g. a hardware wallet) must call registerSigner after the
+    // create flow returns the AID prefix. The constructor falls back to this
+    // registry when kargs.extern.signer is missing.
+    private static _registry: Map<string, IExternalSigner> = new Map();
+
+    static registerSigner(prefix: string, signer: IExternalSigner): void {
+        ExternSignerModule._registry.set(prefix, signer);
+    }
+
+    static unregisterSigner(prefix: string): void {
+        ExternSignerModule._registry.delete(prefix);
+    }
+
+    static getRegisteredSigner(prefix: string): IExternalSigner | undefined {
+        return ExternSignerModule._registry.get(prefix);
+    }
+
+    private _signer: IExternalSigner;
+    private _pidx: number;
+    private _transferable: boolean;
+    private _dcode: string;
+
+    constructor(pidx: number, kargs: any, aid?: any) {
+        const prefix = aid?.prefix ?? aid?.i;
+        const fromKargs = kargs?.extern?.signer as IExternalSigner | undefined;
+        const fromRegistry = prefix
+            ? ExternSignerModule._registry.get(prefix)
+            : undefined;
+        this._pidx = pidx;
+        const signer = fromKargs ?? fromRegistry;
+        if (!signer) {
+            throw new Error(
+                'ExternSignerModule: no signer in kargs and none registered ' +
+                    'for prefix=' +
+                    prefix +
+                    '. Call ExternSignerModule.registerSigner ' +
+                    'after the extern AID is created.'
+            );
+        }
+        this._signer = signer;
+        this._transferable = kargs?.transferable ?? true;
+        this._dcode = kargs?.dcode ?? MtrDex.Blake3_256;
+    }
+
+    params() {
+        return { pidx: this._pidx, extern_type: 'keri-card' };
+    }
+
+    async incept(transferable: boolean): Promise<IdentifierManagerResult> {
+        this._transferable = transferable;
+        const code = transferable ? MtrDex.Ed25519 : MtrDex.Ed25519N;
+
+        const pubBytes = await this._signer.pubKey();
+        const verfer = new Verfer({ raw: pubBytes, code });
+
+        const nextPubBytes = await this._signer.nextPubKey();
+        const nextVerfer = new Verfer({ raw: nextPubBytes, code });
+        const diger = new Diger({ code: this._dcode }, nextVerfer.qb64b);
+
+        return [[verfer.qb64], [diger.qb64]];
+    }
+
+    async rotate(
+        ncodes: string[],
+        transferable: boolean,
+        states?: KeyState[],
+        rstates?: KeyState[]
+    ): Promise<IdentifierManagerResult> {
+        this._transferable = transferable;
+        const code = transferable ? MtrDex.Ed25519 : MtrDex.Ed25519N;
+
+        await this._signer.rotate();
+
+        const pubBytes = await this._signer.pubKey();
+        const verfer = new Verfer({ raw: pubBytes, code });
+
+        const nextPubBytes = await this._signer.nextPubKey();
+        const nextVerfer = new Verfer({ raw: nextPubBytes, code });
+        const diger = new Diger({ code: this._dcode }, nextVerfer.qb64b);
+
+        return [[verfer.qb64], [diger.qb64]];
+    }
+
+    async sign(
+        ser: Uint8Array,
+        indexed = true,
+        indices?: number[],
+        ondices?: Array<number | undefined>
+    ): Promise<SignResult> {
+        const sig = await this._signer.sign(ser);
+
+        if (indexed) {
+            const i = indices?.[0] ?? 0;
+            const o = ondices?.[0];
+            const only = o === undefined;
+            let code: string;
+            if (only) {
+                code =
+                    i <= 63
+                        ? IdrDex.Ed25519_Crt_Sig
+                        : IdrDex.Ed25519_Big_Crt_Sig;
+            } else {
+                code =
+                    o === i && i <= 63
+                        ? IdrDex.Ed25519_Sig
+                        : IdrDex.Ed25519_Big_Sig;
+            }
+            return [new Siger({ raw: sig, code, index: i, ondex: o }).qb64];
+        } else {
+            return [new Cigar({ raw: sig, code: MtrDex.Ed25519_Sig }).qb64];
+        }
+    }
+}

--- a/src/keri/app/externSigner.ts
+++ b/src/keri/app/externSigner.ts
@@ -116,13 +116,20 @@ export class ExternSignerModule implements IdentifierManager {
         ser: Uint8Array,
         indexed = true,
         indices?: number[],
-        ondices?: Array<number | undefined>
+        ondices?: Array<number | undefined>,
+        rotated?: boolean
     ): Promise<SignResult> {
         const sig = await this._signer.sign(ser);
 
         if (indexed) {
             const i = indices?.[0] ?? 0;
-            const o = ondices?.[0];
+            // For a rotation the new current key was the prior next at
+            // ondex=i, so the siger must carry the ondex (same default as
+            // SaltyKeeper). Inception stays current-only (ondex undefined).
+            let o = ondices?.[0];
+            if (o === undefined && rotated) {
+                o = i;
+            }
             const only = o === undefined;
             let code: string;
             if (only) {

--- a/src/keri/core/keeping.ts
+++ b/src/keri/core/keeping.ts
@@ -21,7 +21,11 @@ import {
 
 /** External module definition */
 export interface ExternalModuleType {
-    new (pidx: number, args: IdentifierManagerParams): IdentifierManager;
+    new (
+        pidx: number,
+        args: IdentifierManagerParams,
+        aid?: any
+    ): IdentifierManager;
 }
 
 export interface ExternalModule {
@@ -234,7 +238,15 @@ export class IdentifierManagerFactory {
         } else if (Algos.extern in aid) {
             const typ = aid.extern.extern_type;
             if (typ in this.modules) {
-                const mod = new this.modules[typ](aid.extern.pidx, aid.extern);
+                // Pass the full HabState as a 3rd arg so stateful modules
+                // (like ExternSignerModule for the BioCard) can look the
+                // live signer up from a registry by aid.prefix when
+                // aid.extern.signer is not serialised by KERIA.
+                const mod = new this.modules[typ](
+                    aid.extern.pidx,
+                    aid.extern,
+                    aid
+                );
                 return mod;
             } else {
                 throw new Error(`unsupported external module type ${typ}`);

--- a/src/keri/core/serder.ts
+++ b/src/keri/core/serder.ts
@@ -46,6 +46,11 @@ export class Serder {
         return this._sad;
     }
 
+    // back-compat alias: older consumers read `.ked` for the event dict.
+    get ked(): Dict<any> {
+        return this._sad;
+    }
+
     get pre(): string {
         return this._sad['i'];
     }

--- a/test/app/clienting.test.ts
+++ b/test/app/clienting.test.ts
@@ -285,6 +285,54 @@ describe('SignifyClient', () => {
         }
     });
 
+    test('rotateForRecovery PUTs the recovery body to /agent/{caid}', async () => {
+        await libsodium.ready;
+        const { Signer } = await import('../../src/keri/core/signer.ts');
+        const { MtrDex } = await import('../../src/keri/core/matter.ts');
+        const { Diger } = await import('../../src/keri/core/diger.ts');
+
+        const client = new SignifyClient(url, bran, Tier.low, boot_url);
+        await client.boot();
+        await client.connect();
+
+        // Card fixtures: cardCur (= previously committed next, the one
+        // signing in rot.k[1]) and cardNext (the new next-key digest).
+        const cardCur = new Signer({
+            raw: new Uint8Array(32).fill(0x55),
+            code: MtrDex.Ed25519_Seed,
+        });
+        const cardNext = new Signer({
+            raw: new Uint8Array(32).fill(0x77),
+            code: MtrDex.Ed25519_Seed,
+        });
+        const expectedNdig = new Diger(
+            { code: MtrDex.Blake3_256 },
+            cardNext.verfer.qb64b
+        ).qb64;
+
+        const resp = await client.rotateForRecovery(
+            'abcdefghijk0123456789',
+            cardCur.verfer.qb64,
+            cardNext.verfer.qb64,
+            [],
+            async () => new Uint8Array(0),
+            async () => new Uint8Array(64).fill(0x44)
+        );
+
+        assert.equal(resp.status, 202);
+        const lastCall = fetchMock.mock.calls[fetchMock.mock.calls.length - 1]!;
+        assert.equal(
+            lastCall[0]!,
+            url + '/agent/ELI7pg979AdhmvrjDeam2eAO2SR5niCgnjAJXJHtJose'
+        );
+        assert.equal(lastCall[1]!.method, 'PUT');
+        const body = JSON.parse(lastCall[1]!.body! as string);
+        assert.equal(body.rot.t, 'rot');
+        assert.deepEqual(body.rot.n, [expectedNdig]);
+        // Dual-sig now: new bran's sig + card sig (revealing the old next).
+        assert.equal(body.sigs.length, 2);
+    });
+
     test('includes HTTP status info in error message', async () => {
         await libsodium.ready;
         const bran = '0123456789abcdefghijk';

--- a/test/app/controller.test.ts
+++ b/test/app/controller.test.ts
@@ -485,4 +485,77 @@ describe('Controller', () => {
             assert.equal(ctrl.ridx, beforeRidx + 1);
         });
     });
+
+    describe('rotateOffCardToSeed', () => {
+        // Card-backed -> seed, in two clean single-key rotations.
+        async function backedUpFixture() {
+            await libsodium.ready;
+            const ctrl = new Controller('0123456789abcdefghijk', Tier.low);
+            // the card key the backup committed as next.
+            const cardCur = new Signer({
+                raw: new Uint8Array(32).fill(0x55),
+                code: MtrDex.Ed25519_Seed,
+            });
+            const cardNdig = new Diger(
+                { code: MtrDex.Blake3_256 },
+                cardCur.verfer.qb64b
+            ).qb64;
+            // reach the post-backup state: k=[bran], n=[card].
+            const backup = ctrl.rotateExternalNext([cardNdig]);
+            return { ctrl, cardCur, cardNdig, backup, nbran: 'abcdefghijklmnopqrstu' };
+        }
+
+        it('rot1 reveals the card key, rot2 chains to a bran key, and the KEL is valid', async () => {
+            const { ctrl, cardCur, cardNdig, backup, nbran } =
+                await backedUpFixture();
+            const signRot = async (raw: Uint8Array) => cardCur.sign(raw).raw;
+
+            const body = await ctrl.rotateOffCardToSeed(
+                nbran,
+                cardCur.verfer.qb64,
+                [],
+                vi.fn(),
+                signRot
+            );
+
+            const rot1 = body.rot1 as any;
+            const rot2 = body.rot2 as any;
+
+            // rot1: single-key reveal of the committed card key.
+            assert.deepEqual(rot1.k, [cardCur.verfer.qb64]);
+            assert.deepEqual(rot1.kt, '1');
+            assert.equal(rot1.t, 'rot');
+            assert.equal(rot1.p, (backup.rot as any).d);
+            assert.equal(
+                Number(rot1.s),
+                Number((backup.rot as any).s) + 1
+            );
+
+            // rot2: single-key bran current.
+            assert.equal(rot2.k.length, 1);
+            assert.equal(new Verfer({ qb64: rot2.k[0] }).code, MtrDex.Ed25519);
+            assert.deepEqual(rot2.kt, '1');
+            assert.equal(rot2.p, rot1.d);
+            assert.equal(Number(rot2.s), Number(rot1.s) + 1);
+
+            // THE correctness invariant: rot1 must commit rot2's revealed
+            // key as its next, or the chain is invalid and KERIA rejects it.
+            const rot2KeyDigest = new Diger(
+                { code: MtrDex.Blake3_256 },
+                new Verfer({ qb64: rot2.k[0] }).qb64b
+            ).qb64;
+            assert.deepEqual(rot1.n, [rot2KeyDigest]);
+
+            // sigs: card at index 0 on rot1, bran at index 0 on rot2.
+            assert.equal(body.sigs1.length, 1);
+            assert.ok(body.sigs1[0].startsWith('A'));
+            assert.equal(body.sigs2.length, 1);
+            assert.ok(body.sigs2[0].startsWith('A'));
+
+            // local state landed on rot2 (phone-controlled, single-key).
+            assert.deepEqual((ctrl as any).keys, [rot2.k[0]]);
+            assert.equal(ctrl.serder.sad.d, rot2.d);
+            void cardNdig;
+        });
+    });
 });

--- a/test/app/controller.test.ts
+++ b/test/app/controller.test.ts
@@ -555,7 +555,37 @@ describe('Controller', () => {
             // local state landed on rot2 (phone-controlled, single-key).
             assert.deepEqual((ctrl as any).keys, [rot2.k[0]]);
             assert.equal(ctrl.serder.sad.d, rot2.d);
+            // ridx tracks the CURRENT key of the FRESH bran = 0.
+            assert.equal(ctrl.ridx, 0);
             void cardNdig;
+        });
+
+        it('a following backup reveals the committed next (ridx stays aligned)', async () => {
+            const { ctrl, cardCur, nbran } = await backedUpFixture();
+            const body = await ctrl.rotateOffCardToSeed(
+                nbran,
+                cardCur.verfer.qb64,
+                [],
+                vi.fn(),
+                async (raw: Uint8Array) => cardCur.sign(raw).raw
+            );
+            const committedNext = (body.rot2 as any).n[0];
+
+            // Now back up to a card again. rotateExternalNext must reveal the
+            // key card->seed committed as next (nb1), i.e. H(new k[0]) === n.
+            const nextCardNdig = new Diger(
+                { code: MtrDex.Blake3_256 },
+                new Signer({
+                    raw: new Uint8Array(32).fill(0x66),
+                    code: MtrDex.Ed25519_Seed,
+                }).verfer.qb64b
+            ).qb64;
+            const rot = ctrl.rotateExternalNext([nextCardNdig]);
+            const revealedDigest = new Diger(
+                { code: MtrDex.Blake3_256 },
+                new Verfer({ qb64: (rot.rot as any).k[0] }).qb64b
+            ).qb64;
+            assert.equal(revealedDigest, committedNext);
         });
     });
 });

--- a/test/app/controller.test.ts
+++ b/test/app/controller.test.ts
@@ -1,10 +1,16 @@
 import { Controller } from '../../src/keri/app/controller.ts';
-import { assert, describe, it } from 'vitest';
+import { assert, describe, expect, it, vi } from 'vitest';
 import libsodium from 'libsodium-wrappers-sumo';
 import { openManager } from '../../src/keri/core/manager.ts';
+import { Salter } from '../../src/keri/core/salter.ts';
 import { Signer } from '../../src/keri/core/signer.ts';
+import { Verfer } from '../../src/keri/core/verfer.ts';
+import { Diger } from '../../src/keri/core/diger.ts';
+import { Cipher } from '../../src/keri/core/cipher.ts';
+import { Encrypter } from '../../src/keri/core/encrypter.ts';
+import { Decrypter } from '../../src/keri/core/decrypter.ts';
 import { MtrDex } from '../../src/keri/core/matter.ts';
-import { Tier, randomPasscode } from '../../src/index.ts';
+import { Tier, randomPasscode, b } from '../../src/index.ts';
 
 describe('Controller', () => {
     it('manage account AID signing and agent verification', async () => {
@@ -54,5 +60,429 @@ describe('Controller', () => {
         const controller2 = new Controller(passcode2, Tier.low);
 
         assert.notEqual(controller1.pre, controller2.pre);
+    });
+
+    describe('setExternalNext', () => {
+        // Build a Signer/Verfer pair to act as the "card key" the host
+        // wants to commit as next.
+        function makeCardKey() {
+            const raw = new Uint8Array(32).fill(0x42);
+            const signer = new Signer({ raw, code: MtrDex.Ed25519_Seed });
+            const ndig = new Diger(
+                { code: MtrDex.Blake3_256 },
+                signer.verfer.qb64b
+            ).qb64;
+            return { signer, pubQb64: signer.verfer.qb64, ndig };
+        }
+
+        it('rebuilds the inception serder with the override ndigs', async () => {
+            await libsodium.ready;
+            const ctrl = new Controller(randomPasscode(), Tier.low);
+            const { ndig } = makeCardKey();
+            const beforePre = ctrl.pre;
+
+            ctrl.setExternalNext([ndig]);
+
+            assert.deepEqual(ctrl.ndigs, [ndig]);
+            assert.deepEqual(ctrl.serder.sad.n, [ndig]);
+            // The prefix changes because the inception event's digest
+            // now includes the new n.
+            assert.notEqual(ctrl.pre, beforePre);
+            assert.equal(ctrl.serder.sad.t, 'icp');
+        });
+
+        it('throws when ridx > 0 (override only allowed at incept)', async () => {
+            await libsodium.ready;
+            const ctrl = new Controller(randomPasscode(), Tier.low);
+            ctrl.ridx = 1;
+            const { ndig } = makeCardKey();
+
+            assert.throws(() => ctrl.setExternalNext([ndig]), /already rotated/);
+        });
+
+        it('throws when ndigs is empty', async () => {
+            await libsodium.ready;
+            const ctrl = new Controller(randomPasscode(), Tier.low);
+            assert.throws(() => ctrl.setExternalNext([]), /ndigs required/);
+        });
+    });
+
+    describe('rotateForRecovery', () => {
+        // Build a fixture controller, a card signer to play the role of
+        // the previously committed next-key, and helpers to construct
+        // encrypted material for salty / randy / extern AIDs.
+        function makeFixture() {
+            const ctrlBran = '0123456789abcdefghijk';
+            const ctrl = new Controller(ctrlBran, Tier.low);
+
+            // Two distinct card signers: cardCur acts as the priv that
+            // decrypts the OLD sxlt (= the previously committed next-key
+            // KERIA encrypted under). cardNext is the new next-key the
+            // host wants to commit in this rotation.
+            const cardCurRaw = new Uint8Array(32).fill(0x55);
+            const cardCur = new Signer({
+                raw: cardCurRaw,
+                code: MtrDex.Ed25519_Seed,
+            });
+            const cardNextRaw = new Uint8Array(32).fill(0x77);
+            const cardNext = new Signer({
+                raw: cardNextRaw,
+                code: MtrDex.Ed25519_Seed,
+            });
+
+            return { ctrl, cardCur, cardNext, nbran: 'abcdefghijklmnopqrstu' };
+        }
+
+        function encryptForCard(plain: Uint8Array, cardPubQb64: string): string {
+            const enc = new Encrypter({}, b(cardPubQb64));
+            return enc.encrypt(plain).qb64;
+        }
+
+        it('builds dual-key rot: k=[new bran, cardCur], threshold [1,0], n=[H(cardNext)]', async () => {
+            await libsodium.ready;
+            const { ctrl, cardCur, cardNext, nbran } = makeFixture();
+            const expectedNdig = new Diger(
+                { code: MtrDex.Blake3_256 },
+                cardNext.verfer.qb64b
+            ).qb64;
+
+            const decryptOld = vi.fn();
+            const signRot = vi.fn().mockResolvedValue(new Uint8Array(64).fill(0xAA));
+
+            const body = await ctrl.rotateForRecovery(
+                nbran,
+                cardCur.verfer.qb64,
+                cardNext.verfer.qb64,
+                [], // no AIDs to migrate
+                decryptOld,
+                signRot
+            );
+
+            // Dual-key shape: [new bran current, cardCur revealed as old next].
+            const k = (body.rot as any).k as string[];
+            expect(k.length).toBe(2);
+            const newSignerVerfer = new Verfer({ qb64: k[0] });
+            assert.equal(newSignerVerfer.code, MtrDex.Ed25519);
+            assert.equal(k[1], cardCur.verfer.qb64);
+            assert.deepEqual((body.rot as any).kt, ['1', '0']);
+
+            assert.deepEqual((body.rot as any).n, [expectedNdig]);
+            assert.equal((body.rot as any).t, 'rot');
+        });
+
+        it('forwards rot.raw to signRot once; produces two sigs (new bran at 0, card at 1)', async () => {
+            await libsodium.ready;
+            const { ctrl, cardCur, cardNext, nbran } = makeFixture();
+            const sigBytes = new Uint8Array(64).fill(0xBB);
+            const signRot = vi.fn().mockResolvedValue(sigBytes);
+            const decryptOld = vi.fn();
+
+            const body = await ctrl.rotateForRecovery(
+                nbran,
+                cardCur.verfer.qb64,
+                cardNext.verfer.qb64,
+                [],
+                decryptOld,
+                signRot
+            );
+
+            expect(signRot).toHaveBeenCalledTimes(1);
+            const callArg = signRot.mock.calls[0][0] as Uint8Array;
+            assert.ok(callArg instanceof Uint8Array);
+            assert.ok(callArg.length > 0);
+
+            // Two sigs: new bran's signer at index 0 (code A), card sig at
+            // index 1 ondex 0 (code 2A, the big-sig indexer).
+            assert.equal(body.sigs.length, 2);
+            assert.ok(body.sigs[0].startsWith('AA'));
+            assert.ok(body.sigs[1].startsWith('2A'));
+        });
+
+        it('re-encrypts salty sxlt by calling decryptOld once per AID then encrypting under nextCardPub', async () => {
+            await libsodium.ready;
+            const { ctrl, cardCur, cardNext, nbran } = makeFixture();
+
+            // The plaintext we put through the round-trip must be a valid
+            // qb64 matter — that's what Encrypter parses. A Salter qb64
+            // is the natural fit (it's what real KERIA sxlts decrypt to).
+            const plainSalter = new Salter({
+                raw: new Uint8Array(16).fill(0x33),
+            });
+            const plaintext = b(plainSalter.qb64);
+            const oldSxlt = encryptForCard(plaintext, cardCur.verfer.qb64);
+            const aids = [
+                {
+                    prefix: 'EAlice___________________________________01',
+                    salty: { sxlt: oldSxlt },
+                },
+            ];
+
+            // Decrypt callback: this is what the wallet wires to the
+            // card + libsodium. In test we just decrypt using cardCur's
+            // priv via the standard Decrypter to mimic what the card
+            // would return.
+            const decryptOld = vi.fn(async (cipherQb64: string) => {
+                const dec = new Decrypter({}, cardCur.qb64b);
+                return b(dec.decrypt(null, new Cipher({ qb64: cipherQb64 })).qb64);
+            });
+            const signRot = vi.fn().mockResolvedValue(new Uint8Array(64));
+
+            const body = await ctrl.rotateForRecovery(
+                nbran,
+                cardCur.verfer.qb64,
+                cardNext.verfer.qb64,
+                aids,
+                decryptOld,
+                signRot
+            );
+
+            expect(decryptOld).toHaveBeenCalledTimes(1);
+            expect(decryptOld).toHaveBeenCalledWith(oldSxlt);
+
+            const newKey = body.keys[aids[0].prefix];
+            assert.ok(newKey?.sxlt, 'expected new salty sxlt in body');
+            assert.notEqual(newKey.sxlt, oldSxlt);
+
+            // And the new sxlt round-trips: decrypt it with cardNext's
+            // priv and verify the original plaintext is recovered.
+            const dec = new Decrypter({}, cardNext.qb64b);
+            const recovered = dec.decrypt(null, new Cipher({ qb64: newKey.sxlt })).qb64;
+            assert.deepEqual(b(recovered), plaintext);
+        });
+
+        it('re-encrypts randy AIDs by decrypting every prxs and nxts blob', async () => {
+            await libsodium.ready;
+            const { ctrl, cardCur, cardNext, nbran } = makeFixture();
+
+            // Same constraint as the salty test: the plaintexts must be
+            // valid qb64 matter. Use Salter qb64s for the prxs/nxts
+            // fixtures (they stand in for encrypted signer seeds).
+            const mkSalt = (fill: number) =>
+                new Salter({ raw: new Uint8Array(16).fill(fill) }).qb64;
+            const prxsPlain = [b(mkSalt(0xA1)), b(mkSalt(0xA2))];
+            const nxtsPlain = [b(mkSalt(0xB1))];
+            const aids = [
+                {
+                    prefix: 'EBob_____________________________________02',
+                    randy: {
+                        prxs: prxsPlain.map((p) => encryptForCard(p, cardCur.verfer.qb64)),
+                        nxts: nxtsPlain.map((p) => encryptForCard(p, cardCur.verfer.qb64)),
+                    },
+                },
+            ];
+
+            const decryptOld = vi.fn(async (cipherQb64: string) => {
+                const dec = new Decrypter({}, cardCur.qb64b);
+                return b(dec.decrypt(null, new Cipher({ qb64: cipherQb64 })).qb64);
+            });
+            const signRot = vi.fn().mockResolvedValue(new Uint8Array(64));
+
+            const body = await ctrl.rotateForRecovery(
+                nbran,
+                cardCur.verfer.qb64,
+                cardNext.verfer.qb64,
+                aids,
+                decryptOld,
+                signRot
+            );
+
+            // One call per prxs (2) + one per nxts (1) = 3 total
+            expect(decryptOld).toHaveBeenCalledTimes(3);
+            const newKey = body.keys[aids[0].prefix];
+            assert.equal(newKey.prxs.length, 2);
+            assert.equal(newKey.nxts.length, 1);
+
+            // Round-trip each new blob through cardNext priv.
+            const dec = new Decrypter({}, cardNext.qb64b);
+            for (let i = 0; i < newKey.prxs.length; i++) {
+                const recovered = dec.decrypt(null, new Cipher({ qb64: newKey.prxs[i] })).qb64;
+                assert.deepEqual(b(recovered), prxsPlain[i]);
+            }
+            for (let i = 0; i < newKey.nxts.length; i++) {
+                const recovered = dec.decrypt(null, new Cipher({ qb64: newKey.nxts[i] })).qb64;
+                assert.deepEqual(b(recovered), nxtsPlain[i]);
+            }
+        });
+
+        it('skips extern AIDs (no decrypt calls, no entry in keys)', async () => {
+            await libsodium.ready;
+            const { ctrl, cardCur, cardNext, nbran } = makeFixture();
+            const aids = [
+                {
+                    prefix: 'ECarol___________________________________03',
+                    extern: { extern_type: 'keri-card', pidx: 1 },
+                },
+            ];
+
+            const decryptOld = vi.fn();
+            const signRot = vi.fn().mockResolvedValue(new Uint8Array(64));
+
+            const body = await ctrl.rotateForRecovery(
+                nbran,
+                cardCur.verfer.qb64,
+                cardNext.verfer.qb64,
+                aids,
+                decryptOld,
+                signRot
+            );
+
+            expect(decryptOld).not.toHaveBeenCalled();
+            assert.equal(
+                Object.prototype.hasOwnProperty.call(body.keys, aids[0].prefix),
+                false
+            );
+        });
+
+        // The retrofit path: rotate a wallet that wasn't created with a
+        // recovery card to commit one as the new next-key.
+        describe('rotateWithExternalNext (retrofit)', () => {
+            it('throws when nextOverride is empty', async () => {
+                await libsodium.ready;
+                const { ctrl } = makeFixture();
+                assert.throws(
+                    () => ctrl.rotateWithExternalNext('abcdefghijk0123456789', [], []),
+                    /nextOverride required/
+                );
+            });
+
+            it('builds rot with dual-key shape and the override digest as n', async () => {
+                await libsodium.ready;
+                const { ctrl, cardCur, nbran } = makeFixture();
+                const overrideDigest = new Diger(
+                    { code: MtrDex.Blake3_256 },
+                    cardCur.verfer.qb64b
+                ).qb64;
+
+                const body: any = ctrl.rotateWithExternalNext(nbran, [], [
+                    overrideDigest,
+                ]);
+
+                // Dual-key shape preserved: two keys, threshold ['1','0'].
+                assert.equal((body.rot as any).t, 'rot');
+                assert.equal((body.rot as any).k.length, 2);
+                assert.deepEqual((body.rot as any).kt, ['1', '0']);
+
+                // n is the host override exactly.
+                assert.deepEqual((body.rot as any).n, [overrideDigest]);
+
+                // Two sigs (matches the dual-key shape KERIA expects).
+                assert.equal(body.sigs.length, 2);
+            });
+
+            it('produces a top-level sxlt and persists the new ndigs/serder', async () => {
+                await libsodium.ready;
+                const { ctrl, cardNext, nbran } = makeFixture();
+                const overrideDigest = new Diger(
+                    { code: MtrDex.Blake3_256 },
+                    cardNext.verfer.qb64b
+                ).qb64;
+
+                const body: any = ctrl.rotateWithExternalNext(nbran, [], [
+                    overrideDigest,
+                ]);
+
+                // Top-level sxlt comes from the wrapped rotate() and
+                // travels through unchanged.
+                assert.ok(
+                    typeof body.sxlt === 'string' && body.sxlt.length > 0,
+                    'expected top-level sxlt'
+                );
+                // Internal state reflects the override and the rotation.
+                // Note: standard rotate() doesn't auto-increment ridx,
+                // so we don't check it here.
+                assert.deepEqual(ctrl.ndigs, [overrideDigest]);
+                assert.equal(ctrl.serder.sad.t, 'rot');
+            });
+        });
+
+        it('aeidUnderNewBran: sxlt decrypts under new bran signer; n[] stays card-bound', async () => {
+            await libsodium.ready;
+            const { ctrl, cardCur, cardNext, nbran } = makeFixture();
+
+            const plainSalter = new Salter({
+                raw: new Uint8Array(16).fill(0x44),
+            });
+            const plaintext = b(plainSalter.qb64);
+            // Old sxlt encrypted under cardCur (the previously committed next-key).
+            const enc = new Encrypter({}, b(cardCur.verfer.qb64));
+            const oldSxlt = enc.encrypt(plaintext).qb64;
+            const aids = [
+                {
+                    prefix: 'EDave____________________________________04',
+                    salty: { sxlt: oldSxlt },
+                },
+            ];
+
+            const decryptOld = vi.fn(async (cipherQb64: string) => {
+                const dec = new Decrypter({}, cardCur.qb64b);
+                return b(dec.decrypt(null, new Cipher({ qb64: cipherQb64 })).qb64);
+            });
+            const signRot = vi.fn().mockResolvedValue(new Uint8Array(64).fill(0xCC));
+
+            const body = await ctrl.rotateForRecovery(
+                nbran,
+                cardCur.verfer.qb64,
+                cardNext.verfer.qb64,
+                aids,
+                decryptOld,
+                signRot,
+                { aeidUnderNewBran: true }
+            );
+
+            // Derive what the new bran's aeid signer is (mirrors controller internals).
+            const newBranQb64 = MtrDex.Salt_128 + 'A' + nbran.substring(0, 21);
+            const newSalter = new Salter({ qb64: newBranQb64 });
+            const newBranSigner = newSalter.signer(MtrDex.Ed25519_Seed, true, '', Tier.low);
+
+            // The per-AID sxlt must decrypt under the new bran signer, not cardNext.
+            const dec = new Decrypter({}, newBranSigner.qb64b);
+            const recovered = dec.decrypt(null, new Cipher({ qb64: body.keys[aids[0].prefix].sxlt })).qb64;
+            assert.deepEqual(b(recovered), plaintext, 'sxlt must decrypt under new bran signer');
+
+            // Top-level sxlt also decrypts under the new bran signer.
+            const recoveredTop = dec.decrypt(null, new Cipher({ qb64: body.sxlt })).qb64;
+            assert.equal(recoveredTop, newBranQb64, 'top-level sxlt must encrypt the new bran');
+
+            // n[] must still commit the card next-pub (card-bound).
+            const expectedNdig = new Diger(
+                { code: MtrDex.Blake3_256 },
+                cardNext.verfer.qb64b
+            ).qb64;
+            assert.deepEqual((body.rot as any).n, [expectedNdig]);
+            // And k[1] is the cardCur verfer (revealed old next).
+            assert.equal((body.rot as any).k[1], cardCur.verfer.qb64);
+        });
+
+        it('mutates this.bran, this.signer, this.ndigs, this.serder, and this.ridx', async () => {
+            await libsodium.ready;
+            const { ctrl, cardCur, cardNext, nbran } = makeFixture();
+            const beforeRidx = ctrl.ridx;
+            const beforeSerderD = ctrl.serder.sad.d;
+            const beforeSigner = ctrl.signer;
+
+            const expectedNbran =
+                MtrDex.Salt_128 + 'A' + nbran.substring(0, 21);
+            const expectedNdig = new Diger(
+                { code: MtrDex.Blake3_256 },
+                cardNext.verfer.qb64b
+            ).qb64;
+
+            await ctrl.rotateForRecovery(
+                nbran,
+                cardCur.verfer.qb64,
+                cardNext.verfer.qb64,
+                [],
+                vi.fn(),
+                vi.fn().mockResolvedValue(new Uint8Array(64))
+            );
+
+            // `bran` is private — narrow via cast for the assertion.
+            assert.equal((ctrl as any).bran, expectedNbran);
+            assert.notEqual(ctrl.signer, beforeSigner);
+            assert.deepEqual(ctrl.ndigs, [expectedNdig]);
+            assert.equal(ctrl.serder.sad.t, 'rot');
+            assert.notEqual(ctrl.serder.sad.d, beforeSerderD);
+            assert.equal(ctrl.ridx, beforeRidx + 1);
+        });
     });
 });

--- a/test/app/externSigner.test.ts
+++ b/test/app/externSigner.test.ts
@@ -1,0 +1,145 @@
+import { describe, it, expect, vi } from 'vitest';
+import { ExternSignerModule, IExternalSigner } from '../../src/keri/app/externSigner.ts';
+import { Verfer } from '../../src/keri/core/verfer.ts';
+import { Diger } from '../../src/keri/core/diger.ts';
+import { Siger } from '../../src/keri/core/siger.ts';
+import { Cigar } from '../../src/keri/core/cigar.ts';
+import { MtrDex } from '../../src/keri/core/matter.ts';
+import { IdrDex } from '../../src/keri/core/indexer.ts';
+import { Algos } from '../../src/keri/core/manager.ts';
+
+const PUB  = new Uint8Array(32).fill(0x01);
+const NEXT = new Uint8Array(32).fill(0x02);
+const SIG  = new Uint8Array(64).fill(0x07);
+const SER  = new Uint8Array(10).fill(0x42);
+
+function makeMock(): IExternalSigner {
+    return {
+        sign:       vi.fn().mockResolvedValue(SIG),
+        pubKey:     vi.fn().mockResolvedValue(PUB),
+        nextPubKey: vi.fn().mockResolvedValue(NEXT),
+        rotate:     vi.fn().mockResolvedValue(undefined),
+    };
+}
+
+function makeModule(mock: IExternalSigner, transferable = true) {
+    return new ExternSignerModule(0, {
+        extern: { signer: mock },
+        transferable,
+    });
+}
+
+describe('ExternSignerModule', () => {
+    describe('params()', () => {
+        it('returns pidx and extern_type', () => {
+            const m = makeModule(makeMock());
+            expect(m.params()).toEqual({ pidx: 0, extern_type: 'keri-card' });
+        });
+
+        it('algo is extern', () => {
+            expect(makeModule(makeMock()).algo).toBe(Algos.extern);
+        });
+    });
+
+    describe('incept()', () => {
+        it('returns verfer qb64 for current key, transferable', async () => {
+            const mock = makeMock();
+            const [verfers] = await makeModule(mock).incept(true);
+            const expected = new Verfer({ raw: PUB, code: MtrDex.Ed25519 });
+            expect(verfers[0]).toBe(expected.qb64);
+        });
+
+        it('uses Ed25519N code when non-transferable', async () => {
+            const mock = makeMock();
+            const [verfers] = await makeModule(mock, false).incept(false);
+            const expected = new Verfer({ raw: PUB, code: MtrDex.Ed25519N });
+            expect(verfers[0]).toBe(expected.qb64);
+        });
+
+        it('returns Blake3_256 diger for next key', async () => {
+            const mock = makeMock();
+            const [, digers] = await makeModule(mock).incept(true);
+            const nextVerfer = new Verfer({ raw: NEXT, code: MtrDex.Ed25519 });
+            const expected = new Diger({ code: MtrDex.Blake3_256 }, nextVerfer.qb64b);
+            expect(digers[0]).toBe(expected.qb64);
+        });
+
+        it('calls pubKey and nextPubKey once each', async () => {
+            const mock = makeMock();
+            await makeModule(mock).incept(true);
+            expect(mock.pubKey).toHaveBeenCalledOnce();
+            expect(mock.nextPubKey).toHaveBeenCalledOnce();
+        });
+    });
+
+    describe('rotate()', () => {
+        it('calls rotate() on the signer before reading keys', async () => {
+            const mock = makeMock();
+            const order: string[] = [];
+            (mock.rotate as any).mockImplementation(() => { order.push('rotate'); return Promise.resolve(); });
+            (mock.pubKey as any).mockImplementation(() => { order.push('pubKey'); return Promise.resolve(PUB); });
+            await makeModule(mock).rotate([], true);
+            expect(order[0]).toBe('rotate');
+        });
+
+        it('returns new current verfer after rotation', async () => {
+            const mock = makeMock();
+            const [verfers] = await makeModule(mock).rotate([], true);
+            const expected = new Verfer({ raw: PUB, code: MtrDex.Ed25519 });
+            expect(verfers[0]).toBe(expected.qb64);
+        });
+
+        it('returns diger of new next key', async () => {
+            const mock = makeMock();
+            const [, digers] = await makeModule(mock).rotate([], true);
+            const nextVerfer = new Verfer({ raw: NEXT, code: MtrDex.Ed25519 });
+            const expected = new Diger({ code: MtrDex.Blake3_256 }, nextVerfer.qb64b);
+            expect(digers[0]).toBe(expected.qb64);
+        });
+    });
+
+    describe('sign() indexed', () => {
+        it('returns Siger qb64 with Ed25519_Sig code when index==ondex and both<=63', async () => {
+            const mock = makeMock();
+            const result = await makeModule(mock).sign(SER, true, [0], [0]);
+            const expected = new Siger({ raw: SIG, code: IdrDex.Ed25519_Sig, index: 0, ondex: 0 });
+            expect(result[0]).toBe(expected.qb64);
+        });
+
+        it('uses Ed25519_Crt_Sig when ondex is undefined (only=true) and index<=63', async () => {
+            const mock = makeMock();
+            const result = await makeModule(mock).sign(SER, true, [0], undefined);
+            const expected = new Siger({ raw: SIG, code: IdrDex.Ed25519_Crt_Sig, index: 0, ondex: undefined });
+            expect(result[0]).toBe(expected.qb64);
+        });
+
+        it('uses Ed25519_Big_Crt_Sig when ondex is undefined and index>63', async () => {
+            const mock = makeMock();
+            const result = await makeModule(mock).sign(SER, true, [64], undefined);
+            const expected = new Siger({ raw: SIG, code: IdrDex.Ed25519_Big_Crt_Sig, index: 64, ondex: undefined });
+            expect(result[0]).toBe(expected.qb64);
+        });
+
+        it('uses Ed25519_Big_Sig when index!=ondex', async () => {
+            const mock = makeMock();
+            const result = await makeModule(mock).sign(SER, true, [1], [2]);
+            const expected = new Siger({ raw: SIG, code: IdrDex.Ed25519_Big_Sig, index: 1, ondex: 2 });
+            expect(result[0]).toBe(expected.qb64);
+        });
+
+        it('calls signer.sign with the full serialization', async () => {
+            const mock = makeMock();
+            await makeModule(mock).sign(SER, true);
+            expect(mock.sign).toHaveBeenCalledWith(SER);
+        });
+    });
+
+    describe('sign() unindexed', () => {
+        it('returns Cigar qb64 with Ed25519_Sig matter code', async () => {
+            const mock = makeMock();
+            const result = await makeModule(mock).sign(SER, false);
+            const expected = new Cigar({ raw: SIG, code: MtrDex.Ed25519_Sig });
+            expect(result[0]).toBe(expected.qb64);
+        });
+    });
+});


### PR DESCRIPTION
Adds external-signer support to signify-ts so a controller's private key can live on an external device (a hardware wallet or the Veridian BioCard) instead of in the client. A new ExternSignerModule (Algos.extern) implements the IdentifierManager interface but never holds the key: signify-ts assembles the icp/rot/ixn events and asks the external device to sign, and a static signer registry lets the manager be rebuilt from a HabState that only carries {extern_type, pidx}, since KERIA cannot serialise a live signer reference. On top of that it adds the card-recovery rotation flows the BioCard demo needs (rotateExternalNext, rotateWithExternalNext, rotateForRecovery with priorDig to chain past an intervening ixn, and rotateOffCardToSeed), fixes the extern signer carrying ondex on rotation, adds a Serder.ked back-compat getter, and covers it all with unit tests. It pairs with the KERIA feat/extern-keeper branch, which adds the matching ExternKeeper on the agent side.