### PR TITLE
chore: revert isith on rotation, merged to the wrong base

### DIFF
--- a/src/keri/app/aiding.ts
+++ b/src/keri/app/aiding.ts
@@ -41,7 +41,6 @@ export interface CreateIdentiferArgs {
 /** Arguments required to rotate an identfier */
 export interface RotateIdentifierArgs {
     transferable?: boolean;
-    isith?: string | number | string[];
     nsith?: string | number | string[];
     toad?: number;
     cuts?: string[];
@@ -357,7 +356,7 @@ export class Identifier {
         const dig = state.d;
         const ridx = parseInt(state.s, 16) + 1;
         const wits = state.b;
-        let isith = kargs.isith ?? state.nt;
+        let isith = state.nt;
 
         let nsith = kargs.nsith ?? isith;
 

--- a/test/app/aiding.test.ts
+++ b/test/app/aiding.test.ts
@@ -599,38 +599,6 @@ describe('Aiding', () => {
             });
         });
 
-        it('Should use the given sign threshold over the previous next threshold', async () => {
-            const member1 = await createMockIdentifierState(randomUUID(), bran);
-            const member2 = await createMockIdentifierState(
-                randomUUID(),
-                randomPasscode()
-            );
-
-            const group = await createMockIdentifierState(randomUUID(), bran, {
-                algo: Algos.group,
-                mhab: member1,
-                isith: '2',
-                nsith: '1',
-                states: [member1.state, member2.state],
-                rstates: [member1.state, member2.state],
-            });
-            setGroupPriorNextDigests(group, [member1.state, member2.state]);
-
-            client.fetch.mockResolvedValueOnce(Response.json(group));
-            client.fetch.mockResolvedValueOnce(Response.json({}));
-            await client.identifiers().rotate(group.name, {
-                isith: '2',
-                nsith: '1',
-                states: [member1.state, member2.state],
-                rstates: [member1.state, member2.state],
-            });
-            const request = client.getLastMockRequest();
-            expect(request.body.rot).toMatchObject({
-                t: 'rot',
-                kt: '2',
-            });
-        });
-
         it('Uses prior group next digests for replacement rotation ondex', async () => {
             const member1 = await createMockIdentifierState(
                 randomUUID(),


### PR DESCRIPTION
The change went to main, but the wallet installs build/v1.3 and main is not an ancestor of it, so it never reached us. Reopening against build/v1.3. First, revert main.