### PR TITLE
feat: allow setting the signing threshold on rotation

### DIFF
--- a/src/keri/app/aiding.ts
+++ b/src/keri/app/aiding.ts
@@ -52,6 +52,7 @@ export interface CreateIdentifierBody {
 /** Arguments required to rotate an identfier */
 export interface RotateIdentifierArgs {
     transferable?: boolean;
+    isith?: string | number | string[];
     nsith?: string | number | string[];
     toad?: number;
     cuts?: string[];
@@ -374,7 +375,7 @@ export class Identifier {
         const dig = state.d;
         const ridx = parseInt(state.s, 16) + 1;
         const wits = state.b;
-        let isith = state.nt;
+        let isith = kargs.isith ?? state.nt;
 
         let nsith = kargs.nsith ?? isith;
 

--- a/test/app/aiding.test.ts
+++ b/test/app/aiding.test.ts
@@ -654,6 +654,37 @@ describe('Aiding', () => {
                 kt: nextThreshold,
             });
         });
+
+        it('Should use the given sign threshold over the previous next threshold', async () => {
+            const member1 = await createMockIdentifierState(randomUUID(), bran);
+            const member2 = await createMockIdentifierState(
+                randomUUID(),
+                randomPasscode()
+            );
+
+            const group = await createMockIdentifierState(randomUUID(), bran, {
+                algo: Algos.group,
+                mhab: member1,
+                isith: '2',
+                nsith: '1',
+                states: [member1.state, member2.state],
+                rstates: [member1.state, member2.state],
+            });
+
+            client.fetch.mockResolvedValueOnce(Response.json(group));
+            client.fetch.mockResolvedValueOnce(Response.json({}));
+            await client.identifiers().rotate(group.name, {
+                isith: '2',
+                nsith: '1',
+                states: [member1.state, member2.state],
+                rstates: [member1.state, member2.state],
+            });
+            const request = client.getLastMockRequest();
+            expect(request.body.rot).toMatchObject({
+                t: 'rot',
+                kt: '2',
+            });
+        });
     });
 
     describe('Typings test', () => {


### PR DESCRIPTION
Same change as #42, which went to main by mistake. main isn't an ancestor of `build/v1.3` so it never reached the wallet, and it was reverted there in #44.
`RotateIdentifierArgs` had no isith and createRotationData hardcoded the prior nt, so a group couldn't keep its signing threshold across a rotation.
Test adapted to this branch, the one on main used a helper that doesn't exist here.