### PR TITLE
Preserve bytes across ESSR HTTP envelopes

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,33 @@ Typescript source files needs to be transpiled before running scripts or integra
     console.log(actualSignifyClient);
     ```
 
+### ESSR and binary HTTP bodies
+
+`AuthMode.ESSR` signs and encrypts one complete, finite HTTP request and
+response. Its inner message is an ESSR-specific HTTP envelope, not a general
+HTTP transport. The envelope head is ASCII; request and response bodies remain
+exact bytes.
+
+`SignifyClient.fetch()` retains its existing JSON-oriented behavior. Use
+`fetchRequest()` when a KERIA endpoint accepts or returns non-JSON bytes:
+
+```typescript
+const image = new Uint8Array([0x89, 0x50, 0x4e, 0x47]);
+await client.fetchRequest(`/contacts/${prefix}/img`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'image/png' },
+    body: image,
+});
+
+const response = await client.fetchRequest(`/contacts/${prefix}/img`);
+const downloaded = new Uint8Array(await response.arrayBuffer());
+```
+
+ESSR buffers the complete body before sealing or opening it. It does not
+support infinite request bodies or progressive responses such as SSE. Use
+signed-header mode for a live response stream unless a framed ESSR streaming
+protocol is specified in the future.
+
 ### Unit testing
 
 To run unit tests
@@ -141,6 +168,9 @@ TEST_ENVIRONMENT=local npm run test:integration test-integration/credentials.tes
 ```
 
 This changes the discovery urls to use `localhost` instead of the hostnames inside the docker network.
+
+Set `KERIA_URL` and `KERIA_BOOT_URL` to run an integration test against KERIA
+admin and boot interfaces on non-default host ports.
 
 # Diagrams
 

--- a/src/keri/app/clienting.ts
+++ b/src/keri/app/clienting.ts
@@ -223,31 +223,47 @@ export class SignifyClient {
         data?: unknown,
         extraHeaders?: Headers
     ): Promise<Response> {
+        const headers = new Headers(extraHeaders);
+        const body = method == 'GET' ? null : jsonBody(data);
+        if (body) {
+            headers.set('Content-Type', 'application/json');
+        }
+
+        return await this.fetchRequest(path, {
+            method,
+            body,
+            headers,
+        });
+    }
+
+    /**
+     * Fetch a KERIA resource with an exact, finite Fetch API request body.
+     *
+     * Unlike {@link fetch}, this method does not JSON-encode the body. ESSR
+     * buffers and seals the complete request and response, so live or infinite
+     * streams are not supported.
+     *
+     * @param {string} path Path to the KERIA resource
+     * @param {RequestInit} [init] Standard Fetch API request options
+     * @returns {Promise<Response>} A promise to the authenticated response
+     */
+    async fetchRequest(
+        path: string,
+        init: RequestInit = {}
+    ): Promise<Response> {
         if (!this.authn) {
             throw new Error('Client needs to call connect first');
         }
 
-        const headers = new Headers();
+        const headers = new Headers(init.headers);
         headers.set(HEADER_SIG_SENDER, this.controller.pre);
         headers.set(
             HEADER_SIG_TIME,
             new Date().toISOString().replace('Z', '000+00:00')
         );
 
-        if (extraHeaders) {
-            extraHeaders.forEach((value, key) => {
-                headers.append(key, value);
-            });
-        }
-
-        const body = method == 'GET' ? null : jsonBody(data);
-        if (body) {
-            headers.set('Content-Type', 'application/json');
-        }
-
         const baseRequest = new Request(this.url + path, {
-            method,
-            body,
+            ...init,
             headers,
         });
         const request = await this.authn.prepare(
@@ -266,7 +282,7 @@ export class SignifyClient {
         if (!res.ok) {
             const error = await res.text();
             throw new Error(
-                `HTTP ${method} ${path} - ${res.status} ${res.statusText} - ${error}`
+                `HTTP ${baseRequest.method} ${path} - ${res.status} ${res.statusText} - ${error}`
             );
         }
 

--- a/src/keri/core/authing.ts
+++ b/src/keri/core/authing.ts
@@ -16,7 +16,18 @@ import { Cigar } from './cigar.ts';
 import { Siger } from './siger.ts';
 import { Diger } from './diger.ts';
 import { MtrDex } from './matter.ts';
-import { b, d } from './core.ts';
+import { b } from './core.ts';
+
+const HTTP_TOKEN = /^[!#$%&'*+\-.^_`|~0-9A-Za-z]+$/;
+const RESPONSE_STATUS_LINE = /^HTTP\/1\.[01] ([0-9]{3})(?: (.*))?$/;
+const HEADER_SEPARATOR = new Uint8Array([13, 10, 13, 10]);
+
+function contentLengthEquals(value: string, length: number): boolean {
+    return (
+        /^\d+$/.test(value) &&
+        value.replace(/^0+(?=\d)/, '') === length.toString()
+    );
+}
 
 export abstract class Authenticator {
     protected verfer: Verfer;
@@ -224,9 +235,9 @@ export class EssrAuthenticator extends Authenticator {
         headers.set(HEADER_SIG_TIME, dt);
         headers.set('Content-Type', 'application/octet-stream');
 
-        const requestStr = await EssrAuthenticator.serializeRequest(request);
+        const requestBytes = await EssrAuthenticator.serializeRequest(request);
         const raw = libsodium.crypto_box_seal(
-            requestStr,
+            requestBytes,
             this.vx25519Pub
         ) as Uint8Array<ArrayBuffer>;
 
@@ -267,60 +278,61 @@ export class EssrAuthenticator extends Authenticator {
             );
         }
 
-        return await this.unwrap(response, remote, local);
+        return await this.unwrap(response, remote, local, request.method);
     }
 
-    static async serializeRequest(request: Request) {
-        let headers = '';
+    /**
+     * Serialize the finite request as KERIA's ESSR-specific HTTP envelope.
+     *
+     * The HTTP head is ASCII and the body is appended as exact bytes. This is
+     * not a general HTTP serializer and deliberately rejects transfer coding.
+     */
+    static async serializeRequest(request: Request): Promise<Uint8Array> {
+        const body =
+            request.body === null
+                ? new Uint8Array()
+                : new Uint8Array(await request.arrayBuffer());
+        const headers: string[] = [];
+        let contentLength: string | null = null;
+
         request.headers.forEach((value, name) => {
-            headers += `${name}: ${value}\r\n`;
+            const lowerName = name.toLowerCase();
+            if (lowerName === 'transfer-encoding') {
+                throw new Error(
+                    'Failed to serialize ESSR request - Transfer-Encoding is unsupported'
+                );
+            }
+            if (lowerName === 'content-length') {
+                contentLength = value;
+                return;
+            }
+            headers.push(`${name}: ${value}`);
         });
 
-        let body = '';
-        if (request.method !== 'GET' && request.body) {
-            const bytes = await this.streamToBytes(request.body);
-            try {
-                body = new TextDecoder('utf-8', { fatal: true }).decode(bytes);
-            } catch (e) {
+        if (contentLength !== null) {
+            if (!contentLengthEquals(contentLength, body.byteLength)) {
                 throw new Error(
-                    'Failed to serialize ESSR request - body is not valid UTF-8',
-                    { cause: e }
+                    'Failed to serialize ESSR request - Content-Length does not match the body'
                 );
             }
         }
+        headers.push(`content-length: ${body.byteLength}`);
 
-        return `${request.method} ${request.url} HTTP/1.1\r\n${headers}\r\n${body}`;
-    }
-
-    static async streamToBytes(stream: ReadableStream): Promise<Uint8Array> {
-        const reader = stream.getReader();
-        const chunks = [];
-        let done, value;
-
-        while ((({ done, value } = await reader.read()), !done)) {
-            if (value) chunks.push(value);
-        }
-        reader.releaseLock();
-
-        const totalLength = chunks.reduce(
-            (acc, chunk) => acc + chunk.length,
-            0
+        const head = `${request.method} ${request.url} HTTP/1.1\r\n${headers.join('\r\n')}\r\n\r\n`;
+        const headBytes = this.encodeAsciiHead(head, 'request');
+        const serialized = new Uint8Array(
+            headBytes.byteLength + body.byteLength
         );
-        const result = new Uint8Array(totalLength);
-        let offset = 0;
-
-        for (const chunk of chunks) {
-            result.set(chunk, offset);
-            offset += chunk.length;
-        }
-
-        return result;
+        serialized.set(headBytes);
+        serialized.set(body, headBytes.byteLength);
+        return serialized;
     }
 
     private async unwrap(
         wrapper: Response,
         sender: string,
-        receiver: string
+        receiver: string,
+        requestMethod: string
     ): Promise<Response> {
         const signature = wrapper.headers.get(HEADER_SIG);
         if (!signature) {
@@ -370,7 +382,8 @@ export class EssrAuthenticator extends Authenticator {
         }
 
         const response = EssrAuthenticator.deserializeResponse(
-            d(this.decrypt(ciphertext))
+            this.decrypt(ciphertext),
+            requestMethod
         );
 
         if (response.headers.get(HEADER_SIG_SENDER) !== sender) {
@@ -398,31 +411,168 @@ export class EssrAuthenticator extends Authenticator {
         }
     }
 
-    static deserializeResponse(httpString: string): Response {
-        const sep = httpString.indexOf('\r\n\r\n');
-        const head =
-            sep === -1 ? httpString.trimEnd() : httpString.slice(0, sep);
+    /** Parse KERIA's finite ESSR response envelope without decoding its body. */
+    static deserializeResponse(
+        httpBytes: Uint8Array,
+        requestMethod?: string
+    ): Response {
+        const separator = this.findHeaderSeparator(httpBytes);
+        if (separator === -1) {
+            throw new Error(
+                'Failed to deserialize ESSR response - missing CRLFCRLF separator'
+            );
+        }
 
+        const head = this.decodeAsciiHead(
+            httpBytes.subarray(0, separator),
+            'response'
+        );
         const [statusLine, ...headerLines] = head.split('\r\n');
-        const [, statusCode, ...statusTextArr] = statusLine.split(' ');
+        const statusMatch = RESPONSE_STATUS_LINE.exec(statusLine);
+        if (statusMatch === null) {
+            throw new Error(
+                'Failed to deserialize ESSR response - invalid status line'
+            );
+        }
 
-        const body = sep === -1 ? '' : httpString.slice(sep + 4);
+        const status = Number(statusMatch[1]);
+        if (status < 200 || status > 599) {
+            throw new Error(
+                'Failed to deserialize ESSR response - unsupported status code'
+            );
+        }
+        const statusText = statusMatch[2] ?? '';
+        if (
+            [...statusText].some(
+                (character) =>
+                    character.charCodeAt(0) < 32 ||
+                    character.charCodeAt(0) === 127
+            )
+        ) {
+            throw new Error(
+                'Failed to deserialize ESSR response - invalid status text'
+            );
+        }
 
+        const body = httpBytes.slice(separator + HEADER_SEPARATOR.byteLength);
         const headers = new Headers();
+        const contentLengths: string[] = [];
         for (const line of headerLines) {
             const i = line.indexOf(':');
-            if (i !== -1) {
-                headers.append(
-                    line.slice(0, i).trim(),
-                    line.slice(i + 1).trim()
+            const name = line.slice(0, i);
+            if (i < 1 || !HTTP_TOKEN.test(name)) {
+                throw new Error(
+                    'Failed to deserialize ESSR response - invalid header field'
+                );
+            }
+            const value = line.slice(i + 1).trim();
+            if (
+                [...value].some(
+                    (character) =>
+                        (character.charCodeAt(0) < 32 && character !== '\t') ||
+                        character.charCodeAt(0) === 127
+                )
+            ) {
+                throw new Error(
+                    'Failed to deserialize ESSR response - invalid header value'
+                );
+            }
+
+            const lowerName = name.toLowerCase();
+            if (lowerName === 'transfer-encoding') {
+                throw new Error(
+                    'Failed to deserialize ESSR response - Transfer-Encoding is unsupported'
+                );
+            }
+            if (lowerName === 'content-length') {
+                contentLengths.push(value);
+            }
+            headers.append(name, value);
+        }
+
+        if (
+            contentLengths.length > 1 ||
+            (contentLengths.length === 1 && !/^\d+$/.test(contentLengths[0]))
+        ) {
+            throw new Error(
+                'Failed to deserialize ESSR response - invalid Content-Length'
+            );
+        }
+
+        const method = requestMethod?.toUpperCase();
+        const bodyless = method === 'HEAD' || [204, 205, 304].includes(status);
+        if (bodyless && body.byteLength !== 0) {
+            throw new Error(
+                'Failed to deserialize ESSR response - body is forbidden for this response'
+            );
+        }
+
+        if (contentLengths.length === 1) {
+            if (status === 204) {
+                throw new Error(
+                    'Failed to deserialize ESSR response - Content-Length is forbidden for 204'
+                );
+            }
+            if (status === 205 && !contentLengthEquals(contentLengths[0], 0)) {
+                throw new Error(
+                    'Failed to deserialize ESSR response - 205 Content-Length must be zero'
+                );
+            }
+            if (
+                method !== 'HEAD' &&
+                status !== 304 &&
+                !contentLengthEquals(contentLengths[0], body.byteLength)
+            ) {
+                throw new Error(
+                    'Failed to deserialize ESSR response - Content-Length does not match the body'
                 );
             }
         }
 
-        return new Response(body.length ? body : null, {
-            status: Number(statusCode),
-            statusText: statusTextArr.join(' '),
+        return new Response(bodyless || body.byteLength === 0 ? null : body, {
+            status,
+            statusText,
             headers,
         });
+    }
+
+    private static encodeAsciiHead(
+        head: string,
+        messageType: string
+    ): Uint8Array {
+        for (let i = 0; i < head.length; i++) {
+            if (head.charCodeAt(i) > 127) {
+                throw new Error(
+                    `Failed to serialize ESSR ${messageType} - head must be ASCII`
+                );
+            }
+        }
+        return new TextEncoder().encode(head);
+    }
+
+    private static decodeAsciiHead(
+        head: Uint8Array,
+        messageType: string
+    ): string {
+        if (head.some((value) => value > 127)) {
+            throw new Error(
+                `Failed to deserialize ESSR ${messageType} - head must be ASCII`
+            );
+        }
+        return new TextDecoder().decode(head);
+    }
+
+    private static findHeaderSeparator(message: Uint8Array): number {
+        const lastStart = message.byteLength - HEADER_SEPARATOR.byteLength;
+        for (let i = 0; i <= lastStart; i++) {
+            if (
+                HEADER_SEPARATOR.every(
+                    (value, offset) => message[i + offset] === value
+                )
+            ) {
+                return i;
+            }
+        }
+        return -1;
     }
 }

--- a/test-integration/contact-image.test.ts
+++ b/test-integration/contact-image.test.ts
@@ -1,0 +1,36 @@
+import { beforeAll, describe, expect, test } from 'vitest';
+import { SignifyClient } from 'signify-ts';
+import { getOrCreateClient, getOrCreateIdentifier } from './utils/test-util.ts';
+
+let client: SignifyClient;
+let prefix: string;
+
+beforeAll(async () => {
+    client = await getOrCreateClient();
+    [prefix] = await getOrCreateIdentifier(client, 'binary-contact-image', {
+        toad: 0,
+        wits: [],
+    });
+});
+
+describe('contact image byte transport', () => {
+    test('uploads and downloads exact bytes through authenticated fetch', async () => {
+        const image = new Uint8Array([
+            0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0xff, 0xfe, 0x00,
+            0x85,
+        ]);
+        const path = `/contacts/${prefix}/img`;
+
+        const uploaded = await client.fetchRequest(path, {
+            method: 'POST',
+            headers: { 'Content-Type': 'image/png' },
+            body: image,
+        });
+        expect(uploaded.status).toBe(202);
+
+        const downloaded = await client.fetchRequest(path);
+        expect(downloaded.status).toBe(200);
+        expect(downloaded.headers.get('Content-Type')).toBe('image/png');
+        expect(new Uint8Array(await downloaded.arrayBuffer())).toEqual(image);
+    });
+});

--- a/test-integration/utils/resolve-env.ts
+++ b/test-integration/utils/resolve-env.ts
@@ -18,8 +18,8 @@ export function resolveEnvironment(
 ): TestEnvironment {
     const preset = input ?? process.env.TEST_ENVIRONMENT ?? 'docker';
 
-    const url = 'http://127.0.0.1:3901';
-    const bootUrl = 'http://127.0.0.1:3903';
+    const url = process.env.KERIA_URL ?? 'http://127.0.0.1:3901';
+    const bootUrl = process.env.KERIA_BOOT_URL ?? 'http://127.0.0.1:3903';
 
     switch (preset) {
         case 'docker':

--- a/test/app/clienting.test.ts
+++ b/test/app/clienting.test.ts
@@ -353,6 +353,38 @@ describe('SignifyClient', () => {
         );
     });
 
+    test('Client authenticated fetchRequest preserves a binary body', async () => {
+        const prepareSpy = vi.spyOn(
+            SignedHeaderAuthenticator.prototype,
+            'prepare'
+        );
+        const client = new SignifyClient(url, bran, Tier.low, boot_url);
+
+        await expect(
+            client.fetchRequest('/contacts/prefix/img')
+        ).rejects.toThrow('Client needs to call connect first');
+
+        await client.connect();
+        const body = new Uint8Array([0xff, 0xfe, 0, 13, 10, 0x85]);
+        await client.fetchRequest('/contacts/prefix/img', {
+            method: 'POST',
+            body,
+            headers: { 'Content-Type': 'application/octet-stream' },
+        });
+
+        const request = prepareSpy.mock.calls
+            .map((call) => call[0])
+            .find((candidate) =>
+                candidate.url.endsWith('/contacts/prefix/img')
+            )!;
+        assert.equal(request.method, 'POST');
+        assert.equal(
+            request.headers.get('Content-Type'),
+            'application/octet-stream'
+        );
+        assert.deepEqual(new Uint8Array(await request.arrayBuffer()), body);
+    });
+
     test('Sends the request body verbatim, without escaping separators', async () => {
         const prepareSpy = vi.spyOn(
             SignedHeaderAuthenticator.prototype,

--- a/test/core/authing.test.ts
+++ b/test/core/authing.test.ts
@@ -18,6 +18,7 @@ import {
 import { designature, Signage, signature } from '../../src/keri/end/ending.ts';
 import { Diger } from '../../src/keri/core/diger.ts';
 import { Cigar } from '../../src/keri/core/cigar.ts';
+import { Siger } from '../../src/keri/core/siger.ts';
 import { MtrDex } from '../../src/keri/core/matter.ts';
 
 // prettier-ignore
@@ -304,6 +305,7 @@ describe('ESSR Authenticator', () => {
         assert.equal(
             plaintextGet,
             `GET http://127.0.0.1:3901/oobis HTTP/1.1\r
+content-length: 0\r
 \r
 `
         );
@@ -327,6 +329,7 @@ describe('ESSR Authenticator', () => {
             plaintextPost,
             `POST http://127.0.0.1:3901/oobis HTTP/1.1\r
 content-type: text/plain;charset=UTF-8\r
+content-length: 7\r
 \r
 {"a":1}`
         );
@@ -466,7 +469,7 @@ content-type: text/plain;charset=UTF-8\r
                 'EEXekkGu9IAzav6pZVJhkLnjtjM5v3AcyA-pdKUcaGei'
             )
         ).rejects.toThrow(
-            'Invalid ESSR payload, missing or incorrect encrypted sender'
+            'Failed to deserialize ESSR response - missing CRLFCRLF separator'
         );
 
         headers.set(HEADER_SIG_TIME, '2025-01-17T12:00:18.260000+00:00');
@@ -482,7 +485,7 @@ content-type: text/plain;charset=UTF-8\r
                 'EEXekkGu9IAzav6pZVJhkLnjtjM5v3AcyA-pdKUcaGei'
             )
         ).rejects.toThrow(
-            'Invalid ESSR payload, missing or incorrect encrypted sender'
+            'Failed to deserialize ESSR response - missing CRLFCRLF separator'
         );
 
         headers.set(HEADER_SIG_TIME, '2025-01-17T12:04:16.254000+00:00');
@@ -557,6 +560,74 @@ describe('EssrAuthenticator decrypt failure', () => {
     });
 });
 
+describe('EssrAuthenticator binary response', () => {
+    test('Verifies, decrypts, and preserves exact response bytes', async () => {
+        await libsodium.ready;
+        const controllerSigner = new Salter({
+            raw: b('0123456789abcdef'),
+        }).signer();
+        const agentSigner = new Salter({
+            qb64: '0AAwMTIzNDU2Nzg5YWJjZGVm',
+        }).signer(
+            'A',
+            true,
+            'agentagent-ELI7pg979AdhmvrjDeam2eAO2SR5niCgnjAJXJHtJose00',
+            Tier.low
+        );
+        const authn = new EssrAuthenticator(
+            controllerSigner,
+            agentSigner.verfer
+        );
+        const sender = 'EEXekkGu9IAzav6pZVJhkLnjtjM5v3AcyA-pdKUcaGei';
+        const receiver = 'ELI7pg979AdhmvrjDeam2eAO2SR5niCgnjAJXJHtJose';
+        const body = new Uint8Array([0xff, 0xfe, 0, 13, 10, 0x85]);
+        const head = b(
+            'HTTP/1.1 200 OK\r\n' +
+                'content-type: application/octet-stream\r\n' +
+                'content-length: 6\r\n' +
+                `signify-resource: ${sender}\r\n` +
+                '\r\n'
+        );
+        const inner = new Uint8Array(head.byteLength + body.byteLength);
+        inner.set(head);
+        inner.set(body, head.byteLength);
+
+        const controllerBoxPub = libsodium.crypto_sign_ed25519_pk_to_curve25519(
+            controllerSigner.verfer.raw
+        );
+        const ciphertext = libsodium.crypto_box_seal(inner, controllerBoxPub);
+        const dt = '2025-01-17T12:04:16.254000+00:00';
+        const payload = {
+            src: sender,
+            dest: receiver,
+            d: new Diger({ code: MtrDex.Blake3_256 }, ciphertext).qb64,
+            dt,
+        };
+        const markers = new Map<string, Cigar | Siger>();
+        markers.set('signify', agentSigner.sign(b(JSON.stringify(payload))));
+        const headers = new Headers([
+            [HEADER_SIG_SENDER, sender],
+            [HEADER_SIG_DESTINATION, receiver],
+            [HEADER_SIG_TIME, dt],
+        ]);
+        signature([new Signage(markers, false)]).forEach((value, key) =>
+            headers.set(key, value)
+        );
+
+        const response = await authn.verify(
+            new Request('https://example.com/binary'),
+            new Response(ciphertext as Uint8Array<ArrayBuffer>, {
+                status: 200,
+                headers,
+            }),
+            receiver,
+            sender
+        );
+
+        assert.deepEqual(new Uint8Array(await response.arrayBuffer()), body);
+    });
+});
+
 describe('EssrAuthenticator.serializeRequest', () => {
     test('Can serialise a GET request', async () => {
         const request = new Request('http://127.0.0.1:3901/oobis', {
@@ -567,9 +638,10 @@ describe('EssrAuthenticator.serializeRequest', () => {
             },
         });
         assert.equal(
-            await EssrAuthenticator.serializeRequest(request),
+            d(await EssrAuthenticator.serializeRequest(request)),
             `GET http://127.0.0.1:3901/oobis HTTP/1.1\r
 signify-resource: ELI7pg979AdhmvrjDeam2eAO2SR5niCgnjAJXJHtJose\r
+content-length: 0\r
 \r
 `
         );
@@ -587,10 +659,11 @@ signify-resource: ELI7pg979AdhmvrjDeam2eAO2SR5niCgnjAJXJHtJose\r
             },
         });
         assert.equal(
-            await EssrAuthenticator.serializeRequest(request),
+            d(await EssrAuthenticator.serializeRequest(request)),
             `POST http://127.0.0.1:3901/oobis HTTP/1.1\r
 content-type: text/plain;charset=UTF-8\r
 signify-resource: ELI7pg979AdhmvrjDeam2eAO2SR5niCgnjAJXJHtJose\r
+content-length: 7\r
 \r
 {"a":1}`
         );
@@ -606,63 +679,102 @@ signify-resource: ELI7pg979AdhmvrjDeam2eAO2SR5niCgnjAJXJHtJose\r
             },
         });
         assert.equal(
-            await EssrAuthenticator.serializeRequest(request),
+            d(await EssrAuthenticator.serializeRequest(request)),
             `POST http://127.0.0.1:3901/oobis HTTP/1.1\r
 content-type: text/plain;charset=UTF-8\r
 signify-resource: ELI7pg979AdhmvrjDeam2eAO2SR5niCgnjAJXJHtJose\r
+content-length: 2\r
 \r
 Hi`
         );
+    });
+
+    test('Preserves an arbitrary binary body', async () => {
+        const body = new Uint8Array([0xff, 0xfe, 0, 13, 10, 0x85]);
+        const request = new Request('https://[2001:db8::1]/binary', {
+            method: 'POST',
+            body,
+        });
+
+        const serialized = await EssrAuthenticator.serializeRequest(request);
+        assert.match(
+            d(serialized.slice(0, -body.byteLength)),
+            /content-length: 6/
+        );
+        assert.deepEqual(serialized.slice(-body.byteLength), body);
+    });
+
+    test('Rejects unsupported or incoherent framing', async () => {
+        const wrongLength = new Request('https://example.com/binary', {
+            method: 'POST',
+            body: new Uint8Array([1, 2]),
+            headers: { 'Content-Length': '999' },
+        });
+        await expect(
+            EssrAuthenticator.serializeRequest(wrongLength)
+        ).rejects.toThrow('Content-Length does not match the body');
+
+        const transferEncoded = new Request('https://example.com/binary', {
+            method: 'POST',
+            body: new Uint8Array([1, 2]),
+            headers: { 'Transfer-Encoding': 'chunked' },
+        });
+        await expect(
+            EssrAuthenticator.serializeRequest(transferEncoded)
+        ).rejects.toThrow('Transfer-Encoding is unsupported');
     });
 });
 
 describe('EssrAuthenticator.deserializeResponse', () => {
     test('Preserves a body containing raw CRLF', async () => {
-        const response =
-            EssrAuthenticator.deserializeResponse(`HTTP/1.1 200 OK\r
+        const response = EssrAuthenticator.deserializeResponse(
+            b(`HTTP/1.1 200 OK\r
 content-type: application/json\r
 \r
-{"a":"x\r\ny"}`);
+{"a":"x\r\ny"}`)
+        );
         assert.equal(await response.text(), '{"a":"x\r\ny"}');
     });
 
     test('Preserves a body containing a blank line', async () => {
-        const response =
-            EssrAuthenticator.deserializeResponse(`HTTP/1.1 200 OK\r
+        const response = EssrAuthenticator.deserializeResponse(
+            b(`HTTP/1.1 200 OK\r
 content-type: text/plain\r
 \r
 one\r
 \r
-two`);
+two`)
+        );
         assert.equal(await response.text(), 'one\r\n\r\ntwo');
     });
 
     test('Preserves a header value containing a colon-space', async () => {
-        const response =
-            EssrAuthenticator.deserializeResponse(`HTTP/1.1 200 OK\r
+        const response = EssrAuthenticator.deserializeResponse(
+            b(`HTTP/1.1 200 OK\r
 location: http://example.com: 8080\r
 \r
-`);
+`)
+        );
         assert.equal(
             response.headers.get('location'),
             'http://example.com: 8080'
         );
     });
 
-    test('Parses a status-line-only payload with no separator', () => {
-        const response = EssrAuthenticator.deserializeResponse(
-            'HTTP/1.1 204 No Content\r\n'
-        );
-        assert.equal(response.status, 204);
-        assert.equal(response.statusText, 'No Content');
-        assert.equal(response.body, null);
+    test('Rejects a status-line-only payload with no separator', () => {
+        expect(() =>
+            EssrAuthenticator.deserializeResponse(
+                b('HTTP/1.1 204 No Content\r\n')
+            )
+        ).toThrow('missing CRLFCRLF separator');
     });
 
     test('Can deserialise a GET response with no headers', async () => {
-        const response =
-            EssrAuthenticator.deserializeResponse(`HTTP/1.1 204 No Content\r
+        const response = EssrAuthenticator.deserializeResponse(
+            b(`HTTP/1.1 204 No Content\r
 \r
-`);
+`)
+        );
         assert.equal(response.status, 204);
         assert.equal(response.statusText, 'No Content');
         assert.equal(response.headers.has('content-type'), false);
@@ -671,12 +783,13 @@ location: http://example.com: 8080\r
     });
 
     test('Can deserialise a GET response with headers', async () => {
-        const response =
-            EssrAuthenticator.deserializeResponse(`HTTP/1.1 204 No Content\r
+        const response = EssrAuthenticator.deserializeResponse(
+            b(`HTTP/1.1 204 No Content\r
 content-type: text/plain;charset=UTF-8\r
 signify-resource: ELI7pg979AdhmvrjDeam2eAO2SR5niCgnjAJXJHtJose\r
 \r
-`);
+`)
+        );
         assert.equal(response.status, 204);
         assert.equal(response.statusText, 'No Content');
         assert.equal(
@@ -690,13 +803,25 @@ signify-resource: ELI7pg979AdhmvrjDeam2eAO2SR5niCgnjAJXJHtJose\r
         assert.equal(response.body, null);
     });
 
+    test('Allows metadata Content-Length on a bodyless HEAD response', () => {
+        const response = EssrAuthenticator.deserializeResponse(
+            b('HTTP/1.1 200 OK\r\ncontent-length: 42\r\n\r\n'),
+            'HEAD'
+        );
+
+        assert.equal(response.status, 200);
+        assert.equal(response.headers.get('content-length'), '42');
+        assert.equal(response.body, null);
+    });
+
     test('Can deserialise a POST response with a JSON body', async () => {
-        const response =
-            EssrAuthenticator.deserializeResponse(`HTTP/1.1 200 OK\r
+        const response = EssrAuthenticator.deserializeResponse(
+            b(`HTTP/1.1 200 OK\r
 content-type: text/plain;charset=UTF-8\r
 signify-resource: ELI7pg979AdhmvrjDeam2eAO2SR5niCgnjAJXJHtJose\r
 \r
-{"a":1}`);
+{"a":1}`)
+        );
         assert.equal(response.status, 200);
         assert.equal(response.statusText, 'OK');
         assert.equal(
@@ -711,12 +836,13 @@ signify-resource: ELI7pg979AdhmvrjDeam2eAO2SR5niCgnjAJXJHtJose\r
     });
 
     test('Can deserialise a POST response with a text body', async () => {
-        const response =
-            EssrAuthenticator.deserializeResponse(`HTTP/1.1 200 OK\r
+        const response = EssrAuthenticator.deserializeResponse(
+            b(`HTTP/1.1 200 OK\r
 content-type: text/plain;charset=UTF-8\r
 signify-resource: ELI7pg979AdhmvrjDeam2eAO2SR5niCgnjAJXJHtJose\r
 \r
-Hi`);
+Hi`)
+        );
         assert.equal(response.status, 200);
         assert.equal(response.statusText, 'OK');
         assert.equal(
@@ -728,5 +854,52 @@ Hi`);
             'ELI7pg979AdhmvrjDeam2eAO2SR5niCgnjAJXJHtJose'
         );
         assert.deepEqual(await response.text(), 'Hi');
+    });
+
+    test('Preserves an arbitrary binary response body', async () => {
+        const body = new Uint8Array([0xff, 0xfe, 0, 13, 10, 0x85]);
+        const head = b(
+            'HTTP/1.1 200 OK\r\n' +
+                'content-type: application/octet-stream\r\n' +
+                'content-length: 6\r\n' +
+                'signify-resource: ELI7pg979AdhmvrjDeam2eAO2SR5niCgnjAJXJHtJose\r\n' +
+                '\r\n'
+        );
+        const serialized = new Uint8Array(head.byteLength + body.byteLength);
+        serialized.set(head);
+        serialized.set(body, head.byteLength);
+
+        const response = EssrAuthenticator.deserializeResponse(serialized);
+        assert.equal(response.status, 200);
+        assert.equal(
+            response.headers.get('content-type'),
+            'application/octet-stream'
+        );
+        assert.deepEqual(new Uint8Array(await response.arrayBuffer()), body);
+    });
+
+    test.each([
+        [b('HTTP/1.1 200 OK\r\ncontent-length: 2\r\n\r\nabc'), undefined],
+        [b('HTTP/1.1 204 No Content\r\n\r\nbody'), undefined],
+        [b('HTTP/1.1 204 No Content\r\ncontent-length: 0\r\n\r\n'), undefined],
+        [
+            b('HTTP/1.1 205 Reset Content\r\ncontent-length: 1\r\n\r\n'),
+            undefined,
+        ],
+        [b('HTTP/1.1 304 Not Modified\r\n\r\nbody'), undefined],
+        [b('HTTP/1.1 200 OK\r\n\r\nbody'), 'HEAD'],
+        [b('HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\r\n'), undefined],
+        [b('HTTP/2 200 OK\r\n\r\n'), undefined],
+        [
+            new Uint8Array([
+                72, 84, 84, 80, 47, 49, 46, 49, 32, 50, 48, 48, 32, 79, 75, 13,
+                10, 120, 58, 32, 255, 13, 10, 13, 10,
+            ]),
+            undefined,
+        ],
+    ])('Rejects malformed or incoherent responses', (serialized, method) => {
+        expect(() =>
+            EssrAuthenticator.deserializeResponse(serialized, method)
+        ).toThrow();
     });
 });


### PR DESCRIPTION
## Summary

- make ESSR request and response codecs byte-based end to end
- encode and decode only the ASCII HTTP head while preserving every body octet
- add `SignifyClient.fetchRequest()` for exact finite `BodyInit` values while retaining the JSON behavior of `fetch()`
- validate the ESSR-specific framing, status line, headers, `Content-Length`, transfer coding, and bodyless response semantics
- document that one-shot ESSR buffers finite messages and does not carry progressive SSE

## Why this targets `feat/essrTake2`

This is a one-commit follow-on to [WebOfTrust/signify-ts#335](https://github.com/WebOfTrust/signify-ts/pull/335). That PR is still open and its head branch is owned by this fork, so targeting the source branch keeps this review limited to the byte-transport change instead of duplicating all of #335 against upstream `main`.

The corresponding KERIA response-finalization and bounded-stream support is in [WebOfTrust/keria#457](https://github.com/WebOfTrust/keria/pull/457).

## Validation

- `npm run build`
- `npm run pretty:check`
- `npm run lint` (0 errors; 226 existing repository warnings)
- `npm test -- --run` (40 files, 168 tests)
- contact-image integration against the KERIA follow-on in signed-header mode
- contact-image integration against the KERIA follow-on in ESSR mode

The integration test round-trips a 12-byte image containing invalid UTF-8, NUL, CRLF, and `0x85` without mutation.
